### PR TITLE
Change Vite environment for Requesting API base URL

### DIFF
--- a/client/src/app/features/top/apis/index.ts
+++ b/client/src/app/features/top/apis/index.ts
@@ -1,6 +1,6 @@
 import type { Paginated, ApiWorldHeritageDto } from "../types";
 
-const apiBase = "http://localhost:8700".replace(/\/+$/, "");
+const apiBase = import.meta.env.VITE_API_BASE_URL ?? "";
 const ENDPOINT = `${apiBase}/api/v1/heritages`;
 
 type DetailResponse<T> = {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,9 +4,7 @@ import tailwindcss from "tailwindcss";
 import autoprefixer from "autoprefixer";
 import path from "node:path";
 
-export default defineConfig(() => {
-  const apiBase = process.env.VITE_API_BASE_URL ?? "http://localhost:8700";
-
+export default defineConfig(({ mode }) => {
   return {
     plugins: [react()],
     css: {
@@ -20,8 +18,16 @@ export default defineConfig(() => {
         "@features": path.resolve(__dirname, "src/app/features"),
       },
     },
-    define: {
-      "process.env.VITE_API_BASE_URL": JSON.stringify(apiBase),
+    server: {
+      proxy:
+        mode === "development"
+          ? {
+              "/api": {
+                target: "http://localhost:8700",
+                changeOrigin: true,
+              },
+            }
+          : undefined,
     },
   };
 });


### PR DESCRIPTION
## Summary

The API base URL is currently hard-coded (`http://localhost:8700`) in the client code.  
This should be replaced with a value taken from the Vite environment variable (`import.meta.env.VITE_API_BASE_URL`).
