### PR TITLE
Refactor heritage search param mapper for clarity

### DIFF
--- a/client/src/app/features/search/mapper/search-heritages.params.ts
+++ b/client/src/app/features/search/mapper/search-heritages.params.ts
@@ -1,5 +1,5 @@
 import type { HeritageSearchParams } from "./search-heritage.types.ts";
-import { DEFAULT_HERITAGE_SEARCH_PARAMS as D } from "./search-heritage.types.ts";
+import { DEFAULT_HERITAGE_SEARCH_PARAMS as defaultSearchParams } from "./search-heritage.types.ts";
 
 const toNullIfEmpty = (v: string | null): string | null => {
   if (v == null) return null;
@@ -20,19 +20,28 @@ const toIntOrNull = (v: string | null): number | null => {
 const clampMin = (n: number, min: number) => (n < min ? min : n);
 
 export function parseHeritageSearchParams(search: string): HeritageSearchParams {
-  const sp = new URLSearchParams(search);
+  const searchParams = new URLSearchParams(search);
 
-  const search_query = toNullIfEmpty(sp.get("search_query")) ?? D.search_query;
-  const country = toNullIfEmpty(sp.get("country")) ?? D.country;
-  const region = toNullIfEmpty(sp.get("region")) ?? D.region;
-  const category = toNullIfEmpty(sp.get("category")) ?? D.category;
+  const search_query =
+    toNullIfEmpty(searchParams.get("search_query")) ?? defaultSearchParams.search_query;
+  const country = toNullIfEmpty(searchParams.get("country")) ?? defaultSearchParams.country;
+  const region = toNullIfEmpty(searchParams.get("region")) ?? defaultSearchParams.region;
+  const category = toNullIfEmpty(searchParams.get("category")) ?? defaultSearchParams.category;
 
-  const year_inscribed_from = toIntOrNull(sp.get("year_inscribed_from")) ?? D.year_inscribed_from;
-  const year_inscribed_to = toIntOrNull(sp.get("year_inscribed_to")) ?? D.year_inscribed_to;
+  const year_inscribed_from =
+    toIntOrNull(searchParams.get("year_inscribed_from")) ?? defaultSearchParams.year_inscribed_from;
+  const year_inscribed_to =
+    toIntOrNull(searchParams.get("year_inscribed_to")) ?? defaultSearchParams.year_inscribed_to;
 
-  const current_page = clampMin(toIntOrNull(sp.get("current_page")) ?? D.current_page, 1);
+  const current_page = clampMin(
+    toIntOrNull(searchParams.get("current_page")) ?? defaultSearchParams.current_page,
+    1,
+  );
 
-  const per_page = clampMin(toIntOrNull(sp.get("per_page")) ?? D.per_page, 1);
+  const per_page = clampMin(
+    toIntOrNull(searchParams.get("per_page")) ?? defaultSearchParams.per_page,
+    1,
+  );
 
   return {
     search_query,
@@ -47,14 +56,14 @@ export function parseHeritageSearchParams(search: string): HeritageSearchParams 
 }
 
 export function serializeHeritageSearchParams(p: HeritageSearchParams): string {
-  const sp = new URLSearchParams();
+  const searchParams = new URLSearchParams();
 
   const setStr = (k: string, v: string | null, def: string | null) => {
     if (v == null) return;
     const s = v.trim();
     if (!s) return;
     if (def != null && s === def) return;
-    sp.set(k, s);
+    searchParams.set(k, s);
   };
 
   const setNum = (k: string, v: number | null, def: number | null) => {
@@ -62,19 +71,19 @@ export function serializeHeritageSearchParams(p: HeritageSearchParams): string {
     if (!Number.isFinite(v)) return;
     const i = Math.floor(v);
     if (def != null && i === def) return;
-    sp.set(k, String(i));
+    searchParams.set(k, String(i));
   };
 
-  setStr("search_query", p.search_query, D.search_query);
-  setStr("country", p.country, D.country);
-  setStr("region", p.region, D.region);
-  setStr("category", p.category, D.category);
+  setStr("search_query", p.search_query, defaultSearchParams.search_query);
+  setStr("country", p.country, defaultSearchParams.country);
+  setStr("region", p.region, defaultSearchParams.region);
+  setStr("category", p.category, defaultSearchParams.category);
 
-  setNum("year_inscribed_from", p.year_inscribed_from, D.year_inscribed_from);
-  setNum("year_inscribed_to", p.year_inscribed_to, D.year_inscribed_to);
-  setNum("current_page", p.current_page, D.current_page);
-  setNum("per_page", p.per_page, D.per_page);
+  setNum("year_inscribed_from", p.year_inscribed_from, defaultSearchParams.year_inscribed_from);
+  setNum("year_inscribed_to", p.year_inscribed_to, defaultSearchParams.year_inscribed_to);
+  setNum("current_page", p.current_page, defaultSearchParams.current_page);
+  setNum("per_page", p.per_page, defaultSearchParams.per_page);
 
-  const qs = sp.toString();
+  const qs = searchParams.toString();
   return qs ? `?${qs}` : "";
 }


### PR DESCRIPTION
## Description

Rename internal variables for readability and make default param reference explicit.

No behaviour changes intended.

### what i have done

- refactor(search): rename mapper variables and default alias
- search-heritages.params.ts（sp→searchParams、D→defaultSearchParams）