### PR TITLE
Feat/search endangered filter

### DIFF
--- a/client/src/app/features/search/apis/search-api.ts
+++ b/client/src/app/features/search/apis/search-api.ts
@@ -16,6 +16,7 @@ export type SearchParams = {
   category?: string;
   yearInscribedFrom?: number;
   yearInscribedTo?: number;
+  isEndangered?: boolean;
   currentPage?: number;
   perPage?: number;
 };
@@ -72,6 +73,7 @@ export const createSearchApi = ({ apiBase, fetchImpl = fetch }: SearchApiDeps) =
     if (category) queryParams.set("category", category);
     if (yearInscribedFrom) queryParams.set("year_inscribed_from", yearInscribedFrom);
     if (yearInscribedTo) queryParams.set("year_inscribed_to", yearInscribedTo);
+    if (params.isEndangered === true) queryParams.set("is_endangered", "true");
     if (params.currentPage != null) queryParams.set("current_page", String(params.currentPage));
     if (params.perPage != null) queryParams.set("per_page", String(params.perPage));
 

--- a/client/src/app/features/search/components/SearchResultsPage.tsx
+++ b/client/src/app/features/search/components/SearchResultsPage.tsx
@@ -7,6 +7,8 @@ import { HeritageCard } from "@features/top/cards/HeritageCard";
 import { Pagination } from "@features/top/components/Pagination.tsx";
 import { BreadcrumbList } from "@shared/components/BreadcrumbList.tsx";
 import { SearchResultMapComponent } from "@features/search/components/SearchResultMapComponent.tsx";
+import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
 
 type Props = {
   header?: ReactNode;
@@ -31,6 +33,7 @@ export default function SearchResultsPage({
   onPageChange,
   onBackToAllSites,
 }: Props) {
+  const text = useText();
   return (
     <main className="mx-auto max-w-7xl px-4 py-12">
       <div className="sticky top-0 z-20 -mx-4 border-b border-zinc-200 bg-white/95 px-4 py-3 backdrop-blur">
@@ -69,11 +72,12 @@ export default function SearchResultsPage({
                   h-9 rounded-xl border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-700
                   shadow-sm transition hover:bg-zinc-50
                 "
-                aria-label="Back to all sites"
+                aria-label={text.backToAllSites}
               >
-                Back to all sites
+                {text.backToAllSites}
               </button>
             ) : null}
+            <LocaleToggle />
           </div>
         </div>
       </div>
@@ -87,7 +91,7 @@ export default function SearchResultsPage({
 
         {items.length === 0 ? (
           <div className="py-20 text-center">
-            <p className="text-sm text-zinc-600">No sites found.</p>
+            <p className="text-sm text-zinc-600">{text.noSitesFound}</p>
           </div>
         ) : (
           <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">

--- a/client/src/app/features/search/containers/__tests__/search-heritage-container.test.tsx
+++ b/client/src/app/features/search/containers/__tests__/search-heritage-container.test.tsx
@@ -39,6 +39,7 @@ type SearchValues = {
   keyword: string;
   yearInscribedFrom: string;
   yearInscribedTo: string;
+  isEndangered: boolean;
 };
 
 type HeritageSubHeaderProps = {
@@ -144,6 +145,7 @@ const makeParsedParams = (overrides: Partial<HeritageSearchParams> = {}): Herita
   category: null,
   year_inscribed_from: null,
   year_inscribed_to: null,
+  is_endangered: null,
   current_page: 1,
   per_page: 30,
   order: "asc",
@@ -203,6 +205,7 @@ describe("TopPageContainer", () => {
         keyword: "Kyoto",
         yearInscribedFrom: "",
         yearInscribedTo: "",
+        isEndangered: false,
       });
     });
 
@@ -252,6 +255,7 @@ describe("TopPageContainer", () => {
       category: "Cultural",
       year_inscribed_from: 1990,
       year_inscribed_to: null,
+      is_endangered: null,
       current_page: 1,
       per_page: 30,
       order: "asc",

--- a/client/src/app/features/search/containers/search-heritage-form-container.tsx
+++ b/client/src/app/features/search/containers/search-heritage-form-container.tsx
@@ -89,11 +89,19 @@ export function SearchHeritageFormContainer() {
         country: null,
       };
 
-      const search = serializeHeritageSearchParams(nextParams);
+      const baseSearch = serializeHeritageSearchParams(nextParams);
+      const currentLang = new URLSearchParams(location.search).get("lang");
+      const finalParams = new URLSearchParams(
+        baseSearch.startsWith("?") ? baseSearch.slice(1) : baseSearch,
+      );
+      if (currentLang === "ja") finalParams.set("lang", "ja");
+      const finalQueryString = finalParams.toString();
+      const search = finalQueryString ? `?${finalQueryString}` : "";
+
       navigate({ pathname: "/heritages/results", search }, { replace: false });
       setDraft(merged);
     },
-    [draft, navigate, params.per_page, params.order],
+    [draft, navigate, params.per_page, params.order, location.search],
   );
 
   return <HeritageSubHeader value={draft} onChange={handleChange} onSubmit={handleSubmit} />;

--- a/client/src/app/features/search/containers/search-heritage-form-container.tsx
+++ b/client/src/app/features/search/containers/search-heritage-form-container.tsx
@@ -36,6 +36,7 @@ const toSearchValues = (params: HeritageSearchParams): SearchValues => ({
   keyword: params.search_query ?? "",
   yearInscribedFrom: params.year_inscribed_from !== null ? String(params.year_inscribed_from) : "",
   yearInscribedTo: params.year_inscribed_to !== null ? String(params.year_inscribed_to) : "",
+  isEndangered: params.is_endangered === true,
 });
 
 export function SearchHeritageFormContainer() {
@@ -71,6 +72,7 @@ export function SearchHeritageFormContainer() {
         keyword: query.keyword ?? draft.keyword,
         yearInscribedFrom: query.yearInscribedFrom ?? draft.yearInscribedFrom,
         yearInscribedTo: query.yearInscribedTo ?? draft.yearInscribedTo,
+        isEndangered: query.isEndangered ?? draft.isEndangered,
       };
 
       const nextParams: HeritageSearchParams = {
@@ -80,6 +82,7 @@ export function SearchHeritageFormContainer() {
         category: toCategoryOrNull(merged.category),
         year_inscribed_from: toSearchYearOrNull(merged.yearInscribedFrom),
         year_inscribed_to: toSearchYearOrNull(merged.yearInscribedTo),
+        is_endangered: merged.isEndangered ? true : null,
         current_page: 1,
         per_page: params.per_page ?? DEFAULT_TOP_PER_PAGE,
         order: params.order ?? DEFAULT_ORDER,

--- a/client/src/app/features/search/containers/search-heritage-result-container.tsx
+++ b/client/src/app/features/search/containers/search-heritage-result-container.tsx
@@ -50,7 +50,8 @@ const hasSearchParams = (params: HeritageSearchParams): boolean =>
   params.region !== null ||
   params.category !== null ||
   params.year_inscribed_from !== null ||
-  params.year_inscribed_to !== null;
+  params.year_inscribed_to !== null ||
+  params.is_endangered === true;
 
 const toDraftValues = (params: HeritageSearchParams): SearchValues => ({
   region: params.region ?? "",
@@ -58,6 +59,7 @@ const toDraftValues = (params: HeritageSearchParams): SearchValues => ({
   keyword: params.search_query ?? "",
   yearInscribedFrom: params.year_inscribed_from !== null ? String(params.year_inscribed_from) : "",
   yearInscribedTo: params.year_inscribed_to !== null ? String(params.year_inscribed_to) : "",
+  isEndangered: params.is_endangered === true,
 });
 
 const toSearchParams = (draft: SearchValues): HeritageSearchParams => ({
@@ -67,6 +69,7 @@ const toSearchParams = (draft: SearchValues): HeritageSearchParams => ({
   category: draft.category || null,
   year_inscribed_from: draft.yearInscribedFrom ? Number(draft.yearInscribedFrom) : null,
   year_inscribed_to: draft.yearInscribedTo ? Number(draft.yearInscribedTo) : null,
+  is_endangered: draft.isEndangered ? true : null,
   current_page: 1,
 });
 
@@ -76,6 +79,7 @@ const mergeDraft = (currentDraft: SearchValues, partial: Partial<SearchValues>):
   keyword: partial.keyword ?? currentDraft.keyword,
   yearInscribedFrom: partial.yearInscribedFrom ?? currentDraft.yearInscribedFrom,
   yearInscribedTo: partial.yearInscribedTo ?? currentDraft.yearInscribedTo,
+  isEndangered: partial.isEndangered ?? currentDraft.isEndangered,
 });
 
 function useHeritageSearchDraft(params: HeritageSearchParams) {

--- a/client/src/app/features/search/containers/search-heritage-result-container.tsx
+++ b/client/src/app/features/search/containers/search-heritage-result-container.tsx
@@ -82,6 +82,15 @@ const mergeDraft = (currentDraft: SearchValues, partial: Partial<SearchValues>):
   isEndangered: partial.isEndangered ?? currentDraft.isEndangered,
 });
 
+// 現在の URL に lang=ja があれば、遷移先 search にも持たせる (en はデフォルトなので付けない)
+const preserveLang = (nextSearch: string, currentSearch: string): string => {
+  const currentLang = new URLSearchParams(currentSearch).get("lang");
+  if (currentLang !== "ja") return nextSearch;
+  const params = new URLSearchParams(nextSearch.startsWith("?") ? nextSearch.slice(1) : nextSearch);
+  params.set("lang", "ja");
+  return `?${params.toString()}`;
+};
+
 function useHeritageSearchDraft(params: HeritageSearchParams) {
   const [draft, setDraft] = React.useState<SearchValues>(() => toDraftValues(params));
 
@@ -125,9 +134,10 @@ export function SearchHeritageResultsContainer(): React.ReactElement {
 
   const handleClickItem = React.useCallback(
     (id: number) => {
-      navigate(`/heritages/${id}`);
+      const search = preserveLang("", location.search);
+      navigate(`/heritages/${id}${search}`);
     },
-    [navigate],
+    [navigate, location.search],
   );
 
   const handlePageChange = React.useCallback(
@@ -137,7 +147,7 @@ export function SearchHeritageResultsContainer(): React.ReactElement {
         current_page: page,
       };
 
-      const search = serializeHeritageSearchParams(nextParams);
+      const search = preserveLang(serializeHeritageSearchParams(nextParams), location.search);
 
       navigate(
         {
@@ -147,14 +157,14 @@ export function SearchHeritageResultsContainer(): React.ReactElement {
         { replace: false },
       );
     },
-    [navigate, location.pathname, params],
+    [navigate, location.pathname, location.search, params],
   );
 
   const handleSubmit = React.useCallback(
     (partial: Partial<SearchValues>) => {
       const nextDraft = mergeDraft(draft, partial);
       const nextParams = toSearchParams(nextDraft);
-      const search = serializeHeritageSearchParams(nextParams);
+      const search = preserveLang(serializeHeritageSearchParams(nextParams), location.search);
 
       navigate(
         {
@@ -166,13 +176,14 @@ export function SearchHeritageResultsContainer(): React.ReactElement {
 
       setDraft(nextDraft);
     },
-    [draft, navigate, setDraft],
+    [draft, navigate, setDraft, location.search],
   );
 
   // Hooks must be called at the top level before any early returns.
   const handleBackToAllSites = React.useCallback(() => {
-    navigate("/heritages", { replace: true });
-  }, [navigate]);
+    const search = preserveLang("", location.search);
+    navigate(`/heritages${search}`, { replace: true });
+  }, [navigate, location.search]);
 
   const header = (
     <HeritageSubHeader value={draft} onChange={handleChange} onSubmit={handleSubmit} />

--- a/client/src/app/features/search/hooks/__tests__/use-search-heritage-query-test.ts
+++ b/client/src/app/features/search/hooks/__tests__/use-search-heritage-query-test.ts
@@ -101,6 +101,7 @@ const makeParams = (overrides: Partial<HeritageSearchParams> = {}): HeritageSear
   category: null,
   year_inscribed_from: null,
   year_inscribed_to: null,
+  is_endangered: null,
   current_page: 1,
   per_page: 30,
   order: null,

--- a/client/src/app/features/search/hooks/use-search-heritage-query.ts
+++ b/client/src/app/features/search/hooks/use-search-heritage-query.ts
@@ -14,6 +14,7 @@ const toSearchParams = (params: HeritageSearchParams): SearchParams => ({
   category: params.category ?? undefined,
   yearInscribedFrom: params.year_inscribed_from ?? undefined,
   yearInscribedTo: params.year_inscribed_to ?? undefined,
+  isEndangered: params.is_endangered === true ? true : undefined,
   currentPage: params.current_page,
   perPage: params.per_page,
 });

--- a/client/src/app/features/search/mapper/__tests__/search-heritages.params.test.ts
+++ b/client/src/app/features/search/mapper/__tests__/search-heritages.params.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  parseHeritageSearchParams,
+  serializeHeritageSearchParams,
+} from "../search-heritages.params.ts";
+import { DEFAULT_HERITAGE_SEARCH_PARAMS } from "../search-heritage.types.ts";
+import type { HeritageSearchParams } from "../../../../../domain/types.ts";
+
+const baseParams = (overrides: Partial<HeritageSearchParams> = {}): HeritageSearchParams => ({
+  ...DEFAULT_HERITAGE_SEARCH_PARAMS,
+  ...overrides,
+});
+
+describe("parseHeritageSearchParams", () => {
+  it("is_endangered=true is parsed as true", () => {
+    const params = parseHeritageSearchParams("?is_endangered=true");
+    expect(params.is_endangered).toBe(true);
+  });
+
+  it("is_endangered=false is treated as no filter (null)", () => {
+    const params = parseHeritageSearchParams("?is_endangered=false");
+    expect(params.is_endangered).toBeNull();
+  });
+
+  it("missing is_endangered defaults to null", () => {
+    const params = parseHeritageSearchParams("?region=Asia");
+    expect(params.is_endangered).toBeNull();
+  });
+
+  it("garbage is_endangered values fall back to null", () => {
+    const params = parseHeritageSearchParams("?is_endangered=banana");
+    expect(params.is_endangered).toBeNull();
+  });
+});
+
+describe("serializeHeritageSearchParams", () => {
+  it("emits is_endangered=true when params.is_endangered is true", () => {
+    const queryString = serializeHeritageSearchParams(baseParams({ is_endangered: true }));
+    expect(queryString).toContain("is_endangered=true");
+  });
+
+  it("omits is_endangered when null", () => {
+    const queryString = serializeHeritageSearchParams(baseParams({ is_endangered: null }));
+    expect(queryString).not.toContain("is_endangered");
+  });
+
+  it("omits is_endangered when false", () => {
+    const queryString = serializeHeritageSearchParams(baseParams({ is_endangered: false }));
+    expect(queryString).not.toContain("is_endangered");
+  });
+});
+
+describe("round-trip", () => {
+  it("preserves is_endangered=true through serialize -> parse", () => {
+    const queryString = serializeHeritageSearchParams(baseParams({ is_endangered: true }));
+    const parsed = parseHeritageSearchParams(queryString);
+    expect(parsed.is_endangered).toBe(true);
+  });
+
+  it("preserves is_endangered=null through serialize -> parse", () => {
+    const queryString = serializeHeritageSearchParams(baseParams({ is_endangered: null }));
+    const parsed = parseHeritageSearchParams(queryString);
+    expect(parsed.is_endangered).toBeNull();
+  });
+});

--- a/client/src/app/features/search/mapper/search-heritage.types.ts
+++ b/client/src/app/features/search/mapper/search-heritage.types.ts
@@ -7,6 +7,7 @@ export const DEFAULT_HERITAGE_SEARCH_PARAMS: HeritageSearchParams = {
   category: null,
   year_inscribed_from: null,
   year_inscribed_to: null,
+  is_endangered: null,
   current_page: 1,
   per_page: 30,
   order: ID_SORT_OPTIONS.ASC,

--- a/client/src/app/features/search/mapper/search-heritages.params.ts
+++ b/client/src/app/features/search/mapper/search-heritages.params.ts
@@ -58,6 +58,13 @@ const toOrderOrNull = (value: string | null): IdSortOption | null => {
   return isIdSortOption(trimmed) ? trimmed : null;
 };
 
+// "true" だけ true。それ以外 (空 / 不正値 / "false") は null = フィルタなし扱い。
+const toEndangeredOrNull = (value: string | null): boolean | null => {
+  const trimmed = toNullIfEmpty(value);
+  if (trimmed == null) return null;
+  return trimmed === "true" ? true : null;
+};
+
 export function parseHeritageSearchParams(search: string): HeritageSearchParams {
   const searchParams = new URLSearchParams(search);
 
@@ -88,6 +95,9 @@ export function parseHeritageSearchParams(search: string): HeritageSearchParams 
 
   const order = toOrderOrNull(searchParams.get("order")) ?? defaultSearchParams.order;
 
+  const is_endangered =
+    toEndangeredOrNull(searchParams.get("is_endangered")) ?? defaultSearchParams.is_endangered;
+
   return {
     search_query,
     country,
@@ -95,6 +105,7 @@ export function parseHeritageSearchParams(search: string): HeritageSearchParams 
     category,
     year_inscribed_from,
     year_inscribed_to,
+    is_endangered,
     current_page,
     per_page,
     order,
@@ -136,6 +147,11 @@ export function serializeHeritageSearchParams(params: HeritageSearchParams): str
 
   if (params.order != null && params.order !== defaultSearchParams.order) {
     searchParams.set("order", params.order);
+  }
+
+  // 危機遺産: true のときだけ URL に乗せる (false / null は省略 = no filter)
+  if (params.is_endangered === true) {
+    searchParams.set("is_endangered", "true");
   }
 
   const queryString = searchParams.toString();

--- a/client/src/app/features/top/components/HeritageSearchForm.tsx
+++ b/client/src/app/features/top/components/HeritageSearchForm.tsx
@@ -18,6 +18,7 @@ type Props = {
     keyword?: string;
     yearInscribedFrom?: string;
     yearInscribedTo?: string;
+    isEndangered?: boolean;
   }) => void;
 };
 
@@ -58,6 +59,7 @@ export function HeritageSearchForm({ value, onChange, onSubmit }: Props) {
       keyword: searchValues.keyword.trim() || undefined,
       yearInscribedFrom: searchValues.yearInscribedFrom || undefined,
       yearInscribedTo: searchValues.yearInscribedTo || undefined,
+      isEndangered: searchValues.isEndangered || undefined,
     });
   };
 
@@ -121,6 +123,19 @@ export function HeritageSearchForm({ value, onChange, onSubmit }: Props) {
             );
           })}
         </div>
+      </div>
+
+      {/* 危機遺産フラグ */}
+      <div className="px-4 py-2 border-b border-zinc-100">
+        <label className="inline-flex items-center gap-2 text-xs font-semibold text-zinc-700 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={searchValues.isEndangered}
+            onChange={(e) => set({ isEndangered: e.target.checked })}
+            className="h-4 w-4 rounded border-zinc-300 text-rose-600 focus:ring-rose-400"
+          />
+          {text.endangeredOnly}
+        </label>
       </div>
 
       {/* Year + Keyword + Submit */}

--- a/client/src/app/features/top/components/HeritageSearchForm.tsx
+++ b/client/src/app/features/top/components/HeritageSearchForm.tsx
@@ -40,6 +40,7 @@ export function HeritageSearchForm({ value, onChange, onSubmit }: Props) {
     keyword: value?.keyword ?? "",
     yearInscribedFrom: value?.yearInscribedFrom ?? "",
     yearInscribedTo: value?.yearInscribedTo ?? "",
+    isEndangered: value?.isEndangered ?? false,
   });
 
   const searchValues = value ?? internal;

--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -19,6 +19,7 @@ const DEFAULT_SEARCH: SearchValues = {
   keyword: "",
   yearInscribedFrom: "",
   yearInscribedTo: "",
+  isEndangered: false,
 };
 
 const formatCriteriaInline = (criteria: string[] | undefined) =>
@@ -114,6 +115,7 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
     if (next.category) params.set("category", next.category);
     if (next.yearInscribedFrom) params.set("year_inscribed_from", next.yearInscribedFrom);
     if (next.yearInscribedTo) params.set("year_inscribed_to", next.yearInscribedTo);
+    if (next.isEndangered) params.set("is_endangered", "true");
 
     navigate(`/heritages/results?${params.toString()}`);
   };

--- a/client/src/app/features/top/components/heritage-detail/HeritageSubHeader.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageSubHeader.tsx
@@ -30,6 +30,7 @@ export function HeritageSubHeader({ value, onChange, onSubmit }: Props): React.J
     keyword: value?.keyword ?? "",
     yearInscribedFrom: value?.yearInscribedFrom ?? "",
     yearInscribedTo: value?.yearInscribedTo ?? "",
+    isEndangered: value?.isEndangered ?? false,
   });
 
   const current = value ?? internal;

--- a/client/src/domain/types.ts
+++ b/client/src/domain/types.ts
@@ -182,6 +182,7 @@ export interface HeritageSearchParams {
   category: Category | null;
   year_inscribed_from: number | null;
   year_inscribed_to: number | null;
+  is_endangered: boolean | null;
   current_page: number;
   per_page: number;
   order: IdSortOption | null;
@@ -198,4 +199,5 @@ export type SearchValues = {
   keyword: string;
   yearInscribedFrom: string;
   yearInscribedTo: string;
+  isEndangered: boolean;
 };

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -30,6 +30,7 @@
   "reload": "Reload",
   "sortById": "Sort by ID",
   "all": "All",
+  "endangeredOnly": "Endangered only",
   "keyword": "Keyword",
   "keywordPlaceholder": "Name / Country",
   "yearFrom": "From",

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -31,6 +31,8 @@
   "sortById": "Sort by ID",
   "all": "All",
   "endangeredOnly": "Endangered only",
+  "backToAllSites": "Back to all sites",
+  "noSitesFound": "No sites found.",
   "keyword": "Keyword",
   "keywordPlaceholder": "Name / Country",
   "yearFrom": "From",

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -30,6 +30,7 @@
   "reload": "再読み込み",
   "sortById": "ID で並び替え",
   "all": "すべて",
+  "endangeredOnly": "危機遺産のみ表示",
   "keyword": "キーワード",
   "keywordPlaceholder": "名称・国名",
   "yearFrom": "から",

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -31,6 +31,8 @@
   "sortById": "ID で並び替え",
   "all": "すべて",
   "endangeredOnly": "危機遺産のみ表示",
+  "backToAllSites": "一覧に戻る",
+  "noSitesFound": "該当する遺産はありません。",
   "keyword": "キーワード",
   "keywordPlaceholder": "名称・国名",
   "yearFrom": "から",


### PR DESCRIPTION
### PR Content
  - Adds the **Endangered (危機遺産)** filter to the heritage search form: a single checkbox that toggles `is_endangered=true` on the URL and wires it through the domain types, URL parse/serialize, search  
  API, and form/result containers.                                                                                                                                                                            
  - Fixes a long-standing bug where `?lang=ja` was dropped on every search-related navigation, so the search results page reverted to English. Form submit and all four navigations on the results page       
  (pagination, re-submit, item click, back-to-all) now carry `lang=ja` forward when the user is in Japanese mode.                                                                                             
  - Adds a `LocaleToggle` to the search results page header and pulls "Back to all sites" / "No sites found." from the ui-text dictionary so the page actually reflects the locale switch. The h1 brand
  "Search Results" and its subtitle stay untranslated by design (matches the `World Heritage` brand pattern in TopPageTitleBar).                                                                              
                  
## What changed                                                                                                                                                                                             
                  
  ### Endangered filter
  - `HeritageSearchParams` gains `is_endangered: boolean | null`; `SearchValues` gains `isEndangered: boolean`.
  - `parseHeritageSearchParams` reads `is_endangered=true` (anything else → `null`); `serializeHeritageSearchParams` emits the param only when `true`. Round-trip covered by new                              
  `search-heritages.params.test.ts`.                                                                                                                                                                          
  - `SearchParams` (API client) and `useHeritageSearchQuery` thread `isEndangered` to the backend as `is_endangered=true`.                                                                                    
  - `HeritageSearchForm` renders a checkbox above the year/keyword row; `SearchHeritageFormContainer`, `SearchHeritageResultsContainer`, and `HeritageDetailLayout` round-trip the field through their drafts 
  and submit handlers.                                                                                                                                                                                        
  - `endangeredOnly` ui-text key added to `en` (`Endangered only`) and `ja` (`危機遺産のみ表示`).                                                                                                             
                                                                                                                                                                                                              
  ### Lang preservation on search navigations                                                                                                                                                                 
  - `SearchHeritageFormContainer.handleSubmit` reads the current URL's `lang` and re-appends it to the next `/heritages/results` URL.                                                                         
  - `SearchHeritageResultsContainer` gets a small file-local `preserveLang(nextSearch, currentSearch)` helper used by `handleClickItem` / `handlePageChange` / `handleSubmit` / `handleBackToAllSites`.       
  `lang=en` (default) is never written; only `lang=ja` is propagated.
                     
  ### SearchResultsPage localization                                                                                                                                                                          
  - `<LocaleToggle />` placed next to "Back to all sites" so users can switch locale from the results page itself.
  - Button label and empty-state ("No sites found.") read from `useText()`. New keys: `backToAllSites`, `noSitesFound`. 
### Tests
  - [ ] `npm run typecheck` passes
  - [ ] `npm test` passes (14 suites / 74 tests, including new `search-heritages.params.test.ts`)
  - [ ] Manual: visit `/heritages?lang=ja`, open the search form, tick the 危機遺産のみ表示 checkbox, submit. Confirm the result URL becomes `/heritages/results?is_endangered=true&lang=ja` and the page is in Japanese.
  - [ ] Manual: on the results page in `ja`, click pagination / re-submit the form / click an item / click 一覧に戻る. `lang=ja` survives every transition.
  - [ ] Manual: visit `/heritages/results?is_endangered=true` directly (no `lang`). Click the 🇬🇧 toggle in the page header — UI flips to ja, URL gains `&lang=ja`, and reload preserves it.
