### PR TITLE
feat(i18n): add footer i18n keys (EN/JA) [closes #321]

### DIFF
--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -50,5 +50,8 @@
     "North America": "North America",
     "South America": "South America",
     "Oceania": "Oceania"
-  }
+  },
+  "footerTagline": "Every site has a story. Start yours.",
+  "quickExplore": "Quick Explore",
+  "dataSource": "Data source: UNESCO World Heritage Centre"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -50,5 +50,8 @@
     "North America": "北アメリカ",
     "South America": "南アメリカ",
     "Oceania": "オセアニア"
-  }
+  },
+  "footerTagline": "すべての遺産に、物語がある。あなたの探索を始めよう。",
+  "quickExplore": "地域から探す",
+  "dataSource": "データ提供: ユネスコ世界遺産センター"
 }


### PR DESCRIPTION
## Summary
- Add `footerTagline`, `quickExplore`, `dataSource` keys to `en/ui.json`
- Add same keys in Japanese to `ja/ui.json`

## Closes
Closes #321

## Test plan
- [ ] `useText().footerTagline` resolves correctly in EN and JA
- [ ] TypeScript compiles without errors (`UiText` type auto-updates via `typeof en`)