### PR TITLE
feat(layout): implement AppFooter component with logo and tagline [closes #318]

### DIFF
--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -4,17 +4,23 @@ import { WorldHeritageDetailContainer } from "@features/top/containers/world-her
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { AppFooter } from "@shared/layout/AppFooter.tsx";
 
 export function AppRoutes() {
   return (
     <LocaleProvider>
       <BreadcrumbProvider>
-        <Routes>
-          <Route path="/heritages" element={<TopPageContainer />} />
-          <Route path="/heritages/results" element={<SearchHeritageResultsContainer />} />
-          <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
-          <Route path="*" element={<Navigate to="/heritages" replace />} />
-        </Routes>
+        <div className="flex min-h-screen flex-col">
+          <div className="flex-1">
+            <Routes>
+              <Route path="/heritages" element={<TopPageContainer />} />
+              <Route path="/heritages/results" element={<SearchHeritageResultsContainer />} />
+              <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
+              <Route path="*" element={<Navigate to="/heritages" replace />} />
+            </Routes>
+          </div>
+          <AppFooter />
+        </div>
       </BreadcrumbProvider>
     </LocaleProvider>
   );

--- a/client/src/shared/layout/AppFooter.tsx
+++ b/client/src/shared/layout/AppFooter.tsx
@@ -1,0 +1,24 @@
+import { Link } from "react-router-dom";
+import PublicIcon from "@mui/icons-material/Public";
+import { useText } from "@shared/locale/ui-text.ts";
+
+export function AppFooter() {
+  const text = useText();
+
+  return (
+    <footer className="bg-zinc-900 text-zinc-100">
+      <div className="mx-auto max-w-7xl px-4 py-12">
+        <div className="flex flex-col gap-2">
+          <Link
+            to="/heritages"
+            className="flex items-center gap-2 w-fit text-white hover:text-zinc-300 transition-colors"
+          >
+            <PublicIcon fontSize="small" className="text-indigo-400" />
+            <span className="text-base font-bold tracking-tight">World Heritage Explorer</span>
+          </Link>
+          <p className="text-sm text-zinc-400">{text.footerTagline}</p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `src/shared/layout/AppFooter.tsx` with logo (`PublicIcon` + app name) and i18n tagline
- Wrap `AppRoutes` in a flex-column layout so the footer is always pinned to the bottom (`flex min-h-screen flex-col`)

## Closes
Closes #318

## Depends on
#337 (i18n keys)

## Test plan
- [ ] Footer appears at the bottom of all pages (`/heritages`, `/heritages/results`, `/heritages/:id`)
- [ ] Logo link navigates to `/heritages`
- [ ] Tagline switches language when locale is toggled (EN ↔ JA)
- [ ] Footer does not overlap page content on short pages