### PR TITLE
feat(footer): add region quick-links section [closes #319]

### DIFF
--- a/client/src/shared/layout/AppFooter.tsx
+++ b/client/src/shared/layout/AppFooter.tsx
@@ -1,13 +1,14 @@
 import { Link } from "react-router-dom";
 import PublicIcon from "@mui/icons-material/Public";
 import { useText } from "@shared/locale/ui-text.ts";
+import { STUDY_REGIONS } from "../../domain/types.ts";
 
 export function AppFooter() {
   const text = useText();
 
   return (
     <footer className="bg-zinc-900 text-zinc-100">
-      <div className="mx-auto max-w-7xl px-4 py-12">
+      <div className="mx-auto max-w-7xl px-4 py-12 flex flex-col gap-8">
         <div className="flex flex-col gap-2">
           <Link
             to="/heritages"
@@ -17,6 +18,23 @@ export function AppFooter() {
             <span className="text-base font-bold tracking-tight">World Heritage Explorer</span>
           </Link>
           <p className="text-sm text-zinc-400">{text.footerTagline}</p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+            {text.quickExplore}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {STUDY_REGIONS.map((region) => (
+              <Link
+                key={region}
+                to={`/heritages/results?region=${encodeURIComponent(region)}`}
+                className="rounded-full border border-zinc-700 px-3 py-1 text-xs font-medium text-zinc-300 hover:border-indigo-400 hover:text-indigo-300 transition-colors"
+              >
+                {text.regionLabels[region]}
+              </Link>
+            ))}
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Add a "Quick Explore" section to `AppFooter` with link chips for all 6 UNESCO regions
- Each chip navigates to `/heritages/results?region=<Region>` (client-side via `Link`)
- Region labels are i18n-aware via `text.regionLabels`
- Hover state: border and text shift to indigo to match brand color

## Closes
Closes #319

## Depends on
#338 (AppFooter base component)

## Test plan
- [ ] All 6 region chips appear in the footer
- [ ] Clicking a chip navigates to the correct search results page
- [ ] Labels switch language when locale is toggled (EN ↔ JA)
- [ ] Chips wrap correctly on mobile without overflow