### PR TITLE
feat(footer): add UNESCO attribution and copyright [closes #320]

### DIFF
--- a/client/src/shared/layout/AppFooter.tsx
+++ b/client/src/shared/layout/AppFooter.tsx
@@ -36,6 +36,20 @@ export function AppFooter() {
             ))}
           </div>
         </div>
+
+        <hr className="border-zinc-800" />
+
+        <div className="flex flex-col gap-1">
+          <a
+            href="https://whc.unesco.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors w-fit"
+          >
+            {text.dataSource}
+          </a>
+          <p className="text-xs text-zinc-600">© 2026 World Heritage Explorer</p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Add a `<hr>` divider to visually separate attribution from navigation links
- Add a UNESCO World Heritage Centre external link (`target="_blank"` + `rel="noopener noreferrer"`)
- Add copyright line `© 2026 World Heritage Explorer`
- Attribution text is i18n-aware via `text.dataSource`

## Closes
Closes #320

## Depends on
#339 (region quick-links)

## Test plan
- [ ] UNESCO link opens `https://whc.unesco.org` in a new tab
- [ ] `rel="noopener noreferrer"` is present (security check)
- [ ] Attribution text switches language when locale is toggled (EN ↔ JA)
- [ ] Copyright line is visible below the attribution