### PR TITLE
feat(i18n): add header and hero text keys (EN/JA) [closes #315]

### DIFF
--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -53,5 +53,9 @@
   },
   "footerTagline": "Every site has a story. Start yours.",
   "quickExplore": "Quick Explore",
-  "dataSource": "Data source: UNESCO World Heritage Centre"
+  "dataSource": "Data source: UNESCO World Heritage Centre",
+  "exploreRegions": "Explore by Region",
+  "heroHeadline": "1,100+ UNESCO World Heritage Sites",
+  "heroSubheadline": "Search and compare sites from across the globe.",
+  "heroCtaLabel": "Start Exploring"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -53,5 +53,9 @@
   },
   "footerTagline": "すべての遺産に、物語がある。あなたの探索を始めよう。",
   "quickExplore": "地域から探す",
-  "dataSource": "データ提供: ユネスコ世界遺産センター"
+  "dataSource": "データ提供: ユネスコ世界遺産センター",
+  "exploreRegions": "地域から探す",
+  "heroHeadline": "ユネスコ世界遺産1,100件以上",
+  "heroSubheadline": "世界中の遺産を検索・比較しよう。",
+  "heroCtaLabel": "探索を始める"
 }


### PR DESCRIPTION
## Summary
- Add `exploreRegions`, `heroHeadline`, `heroSubheadline`, `heroCtaLabel` to `en/ui.json`
- Add same keys in Japanese to `ja/ui.json`

## Closes
Closes #315

## Test plan
- [ ] `useText().heroHeadline` resolves in both EN and JA
- [ ] TypeScript compiles without errors (`UiText` type auto-updates via `typeof en`)