### PR TITLE
feat(header): add region quick-nav to AppHeader [closes #314]

### DIFF
--- a/client/src/shared/layout/AppHeader.tsx
+++ b/client/src/shared/layout/AppHeader.tsx
@@ -1,20 +1,75 @@
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import PublicIcon from "@mui/icons-material/Public";
 import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import { STUDY_REGIONS } from "../../domain/types.ts";
 
 export function AppHeader() {
+  const text = useText();
+  const [searchParams] = useSearchParams();
+  const activeRegion = searchParams.get("region") ?? "";
+
   return (
     <header className="sticky top-0 z-30 border-b border-zinc-200 bg-white/95 backdrop-blur">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3">
         <Link
           to="/heritages"
-          className="flex items-center gap-2 text-indigo-700 hover:text-indigo-900 transition-colors"
+          className="flex shrink-0 items-center gap-2 text-indigo-700 hover:text-indigo-900 transition-colors"
         >
           <PublicIcon fontSize="small" />
           <span className="text-lg font-extrabold tracking-tight">World Heritage</span>
         </Link>
 
-        <LocaleToggle />
+        <nav
+          aria-label={text.exploreRegions}
+          className="hidden min-w-0 md:flex md:items-center md:gap-1 md:overflow-x-auto"
+        >
+          {STUDY_REGIONS.map((region) => {
+            const isActive = activeRegion === region;
+            return (
+              <Link
+                key={region}
+                to={`/heritages/results?region=${encodeURIComponent(region)}`}
+                className={`
+                  shrink-0 rounded-full px-3 py-1 text-xs font-semibold transition-colors
+                  ${
+                    isActive
+                      ? "bg-indigo-700 text-white"
+                      : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900"
+                  }
+                `}
+              >
+                {text.regionLabels[region]}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <LocaleToggle />
+        </div>
+      </div>
+
+      <div className="flex gap-1 overflow-x-auto px-4 pb-2 md:hidden">
+        {STUDY_REGIONS.map((region) => {
+          const isActive = activeRegion === region;
+          return (
+            <Link
+              key={region}
+              to={`/heritages/results?region=${encodeURIComponent(region)}`}
+              className={`
+                shrink-0 rounded-full px-3 py-1 text-xs font-semibold transition-colors
+                ${
+                  isActive
+                    ? "bg-indigo-700 text-white"
+                    : "border border-zinc-200 text-zinc-600 hover:border-zinc-400"
+                }
+              `}
+            >
+              {text.regionLabels[region]}
+            </Link>
+          );
+        })}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Desktop (`md:`): region chips inline in the header bar between logo and LocaleToggle, hidden overflow
- Mobile: a second row of horizontally-scrollable chips below the main bar
- Active region chip (matching current `?region=` param) is highlighted with `bg-indigo-700 text-white`
- Labels are i18n-aware via `text.regionLabels`

## Closes
Closes #314

## Depends on
#343 (AppHeader base)

## Test plan
- [ ] All 6 region chips appear on desktop (inline in header)
- [ ] All 6 region chips appear on mobile (scrollable row below header)
- [ ] Clicking a chip navigates to `/heritages/results?region=<Region>`
- [ ] The active region is visually highlighted
- [ ] Labels switch language when locale is toggled (EN ↔ JA)
- [ ] No horizontal overflow on mobile