### PR TITLE
feat(layout): create AppLayout shell (AppHeader + AppFooter) [closes #312]

### DIFF
--- a/client/src/shared/layout/AppLayout.tsx
+++ b/client/src/shared/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { AppHeader } from "./AppHeader.tsx";
+import { AppFooter } from "./AppFooter.tsx";
+
+export function AppLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AppHeader />
+      <div className="flex-1">{children}</div>
+      <AppFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `src/shared/layout/AppLayout.tsx` — a single wrapper that composes `AppHeader`, page content, and `AppFooter`
- `flex min-h-screen flex-col` ensures the footer always sticks to the bottom
- `AppRoutes` will be updated to use this layout in the cleanup PR (#317)

## Closes
Closes #312

## Depends on
#344 (AppHeader with region nav), #341 (AppFooter already in main)

## Test plan
- [ ] `AppLayout` renders `AppHeader` above content and `AppFooter` below
- [ ] TypeScript compiles without errors
- [ ] No visual regressions (layout is not yet wired into AppRoutes — that is done in #317)