### PR TITLE
feat(top): add TopPageHero atmospheric banner to top page [closes #316]

### DIFF
--- a/client/src/app/features/top/components/TopPage.tsx
+++ b/client/src/app/features/top/components/TopPage.tsx
@@ -2,30 +2,35 @@ import type { ReactNode } from "react";
 import { Map } from "./Map.tsx";
 
 export default function TopPage({
+  hero,
   titleBar,
   header,
   content,
   pagination,
 }: {
+  hero?: ReactNode;
   titleBar: ReactNode;
   header?: ReactNode;
   content: ReactNode;
   pagination?: ReactNode;
 }) {
   return (
-    <main className="mx-auto max-w-7xl px-4 py-12">
-      {titleBar}
+    <>
+      {hero}
+      <main id="heritage-list" className="mx-auto max-w-7xl px-4 py-12">
+        {titleBar}
 
-      <div>{header}</div>
+        <div>{header}</div>
 
-      <div className="mt-4">
-        <Map />
-      </div>
+        <div className="mt-4">
+          <Map />
+        </div>
 
-      <div className="pt-8">
-        {content}
-        {pagination}
-      </div>
-    </main>
+        <div className="pt-8">
+          {content}
+          {pagination}
+        </div>
+      </main>
+    </>
   );
 }

--- a/client/src/app/features/top/components/TopPageHero.tsx
+++ b/client/src/app/features/top/components/TopPageHero.tsx
@@ -1,0 +1,25 @@
+import { useText } from "@shared/locale/ui-text.ts";
+
+export function TopPageHero() {
+  const text = useText();
+
+  return (
+    <div className="relative overflow-hidden bg-gradient-to-br from-indigo-900 via-indigo-800 to-blue-900">
+      <div className="pointer-events-none absolute -right-24 -top-24 h-96 w-96 rounded-full bg-indigo-700/30 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 -left-24 h-96 w-96 rounded-full bg-blue-700/30 blur-3xl" />
+
+      <div className="relative mx-auto flex h-[300px] max-w-7xl flex-col items-center justify-center px-4 text-center md:h-[400px]">
+        <h2 className="text-3xl font-extrabold tracking-tight text-white md:text-5xl">
+          {text.heroHeadline}
+        </h2>
+        <p className="mt-4 max-w-xl text-base text-indigo-200 md:text-lg">{text.heroSubheadline}</p>
+        <a
+          href="#heritage-list"
+          className="mt-8 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-indigo-700 shadow-lg transition-colors hover:bg-indigo-50"
+        >
+          {text.heroCtaLabel} ↓
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/features/top/containers/top-page-container.tsx
+++ b/client/src/app/features/top/containers/top-page-container.tsx
@@ -4,6 +4,7 @@ import TopPage from "../components/TopPage";
 import { useTopPage } from "../hooks/use-top-page";
 import { SearchHeritageFormContainer } from "@features/search/containers/search-heritage-form-container";
 import { TopPageTitleBar } from "../components/TopPageTitleBar";
+import { TopPageHero } from "../components/TopPageHero";
 import { HeritageList } from "../components/HeritageList";
 import { TopPagePagination } from "../components/TopPagePagination";
 import type { IdSortOption } from "../../../../domain/types";
@@ -115,6 +116,7 @@ export default function TopPageContainer(): React.ReactElement {
 
   return (
     <TopPage
+      hero={<TopPageHero />}
       titleBar={
         <TopPageTitleBar order={order} onChangeOrder={handleChangeOrder} onReload={reload} />
       }


### PR DESCRIPTION
## Summary
- Create `TopPageHero.tsx`: full-width banner with indigo gradient background, decorative blur circles, headline, subheadline, and CTA button
- Add `hero?: ReactNode` prop to `TopPage.tsx` rendered above `<main>` — non-breaking, existing pages unaffected
- Add `id="heritage-list"` to `<main>` so the hero CTA (`href="#heritage-list"`) scrolls to the list
- Wire `<TopPageHero />` into `TopPageContainer`

## Closes
Closes #316

## Depends on
#345 (AppLayout), #342 (i18n keys)

## Test plan
- [ ] Hero banner appears only on `/heritages` (top page)
- [ ] "Start Exploring ↓" button scrolls smoothly to the card grid
- [ ] Headline and subheadline switch language when locale is toggled (EN ↔ JA)
- [ ] No layout regressions on search results or detail pages
- [ ] Renders correctly on mobile (300px height) and desktop (400px height)