### PR TITLE
refactor(routes): wire AppLayout into AppRoutes and clean up LocaleToggle [closes #317]

### DIFF
--- a/client/src/app/features/top/components/TopPageTitleBar.tsx
+++ b/client/src/app/features/top/components/TopPageTitleBar.tsx
@@ -12,7 +12,7 @@ export function TopPageTitleBar({
 }) {
   const text = useText();
   return (
-    <div className="sticky top-0 z-20 -mx-4 border-b border-zinc-200 bg-white/95 px-4 pb-4 pt-4 backdrop-blur">
+    <div className="sticky top-[49px] z-20 -mx-4 border-b border-zinc-200 bg-white/95 px-4 pb-4 pt-4 backdrop-blur">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <h1 className="text-3xl font-extrabold tracking-tight text-indigo-700">

--- a/client/src/app/features/top/components/TopPageTitleBar.tsx
+++ b/client/src/app/features/top/components/TopPageTitleBar.tsx
@@ -1,5 +1,4 @@
 import type { IdSortOption } from "../../../../domain/types.ts";
-import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
 
 export function TopPageTitleBar({
@@ -50,8 +49,6 @@ export function TopPageTitleBar({
               {text.reload}
             </button>
           )}
-
-          <LocaleToggle />
         </div>
       </div>
     </div>

--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -11,7 +11,6 @@ import { textType } from "@shared/styles/typography";
 import { useSetBreadcrumbLabel } from "@features/breadcrumbs/BreadCrumbHooks.ts";
 import { BreadcrumbList } from "@shared/components/BreadcrumbList.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
-import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
 
 const DEFAULT_SEARCH: SearchValues = {
   region: "",
@@ -132,9 +131,8 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
     <div className="min-h-screen bg-zinc-50 text-zinc-900">
       <HeritageSubHeader value={search} onChange={setSearch} onSubmit={handleSubmit} />
 
-      <div className="mx-auto w-full max-w-6xl px-4 mt-6 md:mt-8 flex items-center justify-between">
+      <div className="mx-auto w-full max-w-6xl px-4 mt-6 md:mt-8">
         <HeritageDetailTabs items={tabs} />
-        <LocaleToggle />
       </div>
 
       <div className="mx-auto w-full max-w-6xl px-4 mt-4">

--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -4,23 +4,20 @@ import { WorldHeritageDetailContainer } from "@features/top/containers/world-her
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
-import { AppFooter } from "@shared/layout/AppFooter.tsx";
+import { AppLayout } from "@shared/layout/AppLayout.tsx";
 
 export function AppRoutes() {
   return (
     <LocaleProvider>
       <BreadcrumbProvider>
-        <div className="flex min-h-screen flex-col">
-          <div className="flex-1">
-            <Routes>
-              <Route path="/heritages" element={<TopPageContainer />} />
-              <Route path="/heritages/results" element={<SearchHeritageResultsContainer />} />
-              <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
-              <Route path="*" element={<Navigate to="/heritages" replace />} />
-            </Routes>
-          </div>
-          <AppFooter />
-        </div>
+        <AppLayout>
+          <Routes>
+            <Route path="/heritages" element={<TopPageContainer />} />
+            <Route path="/heritages/results" element={<SearchHeritageResultsContainer />} />
+            <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
+            <Route path="*" element={<Navigate to="/heritages" replace />} />
+          </Routes>
+        </AppLayout>
       </BreadcrumbProvider>
     </LocaleProvider>
   );


### PR DESCRIPTION
## Summary
- Replace the ad-hoc `<div className="flex min-h-screen flex-col">` in `AppRoutes` with `<AppLayout>` — single source of truth for the shell layout
- Remove `<LocaleToggle />` from `TopPageTitleBar` (now rendered once in `AppHeader`)
- Remove `<LocaleToggle />` from `HeritageDetailLayout` (same reason)
- Offset `TopPageTitleBar` sticky position to `top-[49px]` so it scrolls below `AppHeader` (`z-30`) without overlap

## Closes
Closes #317

## Depends on
#346 (all header components in place)

## Test plan
- [ ] `AppHeader` and `AppFooter` appear on all three pages (`/heritages`, `/heritages/results`, `/heritages/:id`)
- [ ] `LocaleToggle` appears exactly once — in the global header
- [ ] `TopPageTitleBar` sticks below `AppHeader` when scrolling (no overlap)
- [ ] Locale toggle still switches language on all pages
- [ ] No TypeScript errors