### PR TITLE
feat(layout): implement AppHeader component [closes #313]

### DIFF
--- a/client/src/shared/layout/AppHeader.tsx
+++ b/client/src/shared/layout/AppHeader.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import PublicIcon from "@mui/icons-material/Public";
+import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
+
+export function AppHeader() {
+  return (
+    <header className="sticky top-0 z-30 border-b border-zinc-200 bg-white/95 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+        <Link
+          to="/heritages"
+          className="flex items-center gap-2 text-indigo-700 hover:text-indigo-900 transition-colors"
+        >
+          <PublicIcon fontSize="small" />
+          <span className="text-lg font-extrabold tracking-tight">World Heritage</span>
+        </Link>
+
+        <LocaleToggle />
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `src/shared/layout/AppHeader.tsx` with sticky header (`sticky top-0 z-30`)
- Logo: `PublicIcon` + "World Heritage" links to `/heritages`
- `LocaleToggle` consolidated into the header

## Closes
Closes #313

## Depends on
#342 ✅ merged