### PR TITLE
feat(card): add hover zoom and card lift animation [closes #324]

### DIFF
--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -73,7 +73,7 @@ export function HeritageCard({
               alt={item.thumbnailUrl ?? title}
               referrerPolicy="no-referrer"
               loading="lazy"
-              className="h-56 w-full object-cover sm:h-64 lg:h-72"
+              className="h-56 w-full object-cover sm:h-64 lg:h-72 transition-transform duration-300 group-hover:scale-105"
             />
           ) : (
             <div className="grid h-56 w-full place-items-center bg-zinc-100 text-sm text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 sm:h-64 lg:h-72">

--- a/client/src/shared/uis/BaseCard.tsx
+++ b/client/src/shared/uis/BaseCard.tsx
@@ -24,11 +24,14 @@ export function BaseCard({
 
   return (
     <Wrapper
-      className="
+      className={`
         group h-full overflow-hidden rounded-2xl border border-zinc-200/70
-        bg-white/70 shadow-sm backdrop-blur transition hover:shadow-md
+        bg-white/70 shadow-sm backdrop-blur
+        transition-all duration-200
+        hover:shadow-xl hover:-translate-y-1
         dark:border-zinc-800 dark:bg-zinc-900/70
-      "
+        ${isInteractive ? "cursor-pointer" : ""}
+      `}
       {...(isInteractive ? { role: "button", tabIndex: 0, onClick, onKeyDown: handleKeyDown } : {})}
     >
       {children}


### PR DESCRIPTION
## Summary
- `BaseCard`: add `cursor-pointer` when interactive, upgrade hover from `shadow-md` to `shadow-xl -translate-y-1` with `transition-all duration-200`
- `HeritageCard`: add `group-hover:scale-105 transition-transform duration-300` to `<img>` — zooms inside the `overflow-hidden` wrapper without bleeding outside rounded corners

## Closes
Closes #324

## Test plan
- [ ] Hovering a card lifts it with a larger shadow
- [ ] Photo zooms in smoothly on hover
- [ ] Cursor shows as `pointer` over the whole card
- [ ] No overflow artifact on rounded corners