### PR TITLE
feat(card): spotlight/featured-card treatment for first result [closes #327]

### DIFF
--- a/client/src/app/features/search/components/SearchResultsPage.tsx
+++ b/client/src/app/features/search/components/SearchResultsPage.tsx
@@ -95,9 +95,9 @@ export default function SearchResultsPage({
           </div>
         ) : (
           <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((it) => (
-              <li key={it.id} className="list-none">
-                <HeritageCard item={it} onClickItem={onClickItem} />
+            {items.map((it, index) => (
+              <li key={it.id} className={`list-none ${index === 0 ? "lg:col-span-2" : ""}`}>
+                <HeritageCard item={it} onClickItem={onClickItem} isSpotlight={index === 0} />
               </li>
             ))}
           </ul>

--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -37,9 +37,11 @@ const CRITERIA_MAX = 4;
 export function HeritageCard({
   item,
   onClickItem,
+  isSpotlight = false,
 }: {
   item: WorldHeritageVm;
   onClickItem?: (id: number) => void;
+  isSpotlight?: boolean;
 }) {
   const text = useText();
 
@@ -73,7 +75,7 @@ export function HeritageCard({
               alt={item.thumbnailUrl ?? title}
               referrerPolicy="no-referrer"
               loading="lazy"
-              className="h-56 w-full object-cover sm:h-64 lg:h-72 transition-transform duration-300 group-hover:scale-105"
+              className={`w-full object-cover transition-transform duration-300 group-hover:scale-105 ${isSpotlight ? "h-64 sm:h-80 lg:h-96" : "h-56 sm:h-64 lg:h-72"}`}
             />
           ) : (
             <div className="grid h-56 w-full place-items-center bg-gradient-to-br from-indigo-50 to-zinc-100 sm:h-64 lg:h-72 dark:from-indigo-950 dark:to-zinc-800">
@@ -110,7 +112,9 @@ export function HeritageCard({
           )}
 
           <div className="absolute inset-x-0 bottom-0 p-4">
-            <h3 className="text-white text-lg font-semibold break-words leading-snug line-clamp-2">
+            <h3
+              className={`text-white font-semibold break-words leading-snug line-clamp-2 ${isSpotlight ? "text-xl lg:text-2xl" : "text-lg"}`}
+            >
               {title}
             </h3>
             {subtitle && <p className="mt-0.5 text-sm text-white/80 line-clamp-1">{subtitle}</p>}

--- a/client/src/app/features/top/components/HeritageList.tsx
+++ b/client/src/app/features/top/components/HeritageList.tsx
@@ -18,9 +18,9 @@ export function HeritageList({
 
   return (
     <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
-      {items.map((it) => (
-        <li key={it.id} className="list-none">
-          <HeritageCard item={it} onClickItem={onClickItem} />
+      {items.map((it, index) => (
+        <li key={it.id} className={`list-none ${index === 0 ? "lg:col-span-2" : ""}`}>
+          <HeritageCard item={it} onClickItem={onClickItem} isSpotlight={index === 0} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- Add `isSpotlight?: boolean` prop to `HeritageCard` (default `false` — non-breaking)
  - Image height: `lg:h-96` vs standard `lg:h-72`
  - Title size: `text-xl lg:text-2xl` vs standard `text-lg`
- `HeritageList`: first card gets `lg:col-span-2` + `isSpotlight={true}` → spans 2 columns on desktop
- `SearchResultsPage`: same treatment applied to search results

## Closes
Closes #327

## Depends on
#351 (no-image fallback)

## Test plan
- [ ] First card spans 2 columns on desktop (`lg:`) with taller image
- [ ] Remaining cards are unchanged (standard single-column width)
- [ ] Mobile layout is unaffected (all cards full-width)
- [ ] Passing no `isSpotlight` prop renders a standard card
- [ ] Works on both top list page and search results page