### PR TITLE
feat(card): thumbnail-style photo-first card redesign [closes #327 #326 #325]

### DIFF
--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -1,38 +1,6 @@
-import type { ReactNode, MouseEvent } from "react";
-import type { WorldHeritageVm, CriteriaCode } from "../../../../domain/types.ts";
+import type { WorldHeritageVm } from "../../../../domain/types.ts";
 import { BaseCard } from "@shared/uis/BaseCard.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
-
-function MetaChip({ children }: { children: ReactNode }) {
-  return (
-    <span
-      className="
-        inline-flex items-center rounded-full
-        bg-zinc-100/70 px-2 py-1 text-xs text-zinc-700
-        dark:bg-zinc-800/60 dark:text-zinc-300
-      "
-    >
-      {children}
-    </span>
-  );
-}
-
-function TagChip({ children }: { children: ReactNode }) {
-  return (
-    <span
-      className="
-        inline-flex items-center rounded-full
-        border border-zinc-200/70 bg-white/70 px-2 py-1 text-xs font-medium text-zinc-700
-        dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-200
-      "
-    >
-      {children}
-    </span>
-  );
-}
-
-const DESC_CLAMP = 2;
-const CRITERIA_MAX = 4;
 
 export function HeritageCard({
   item,
@@ -43,114 +11,64 @@ export function HeritageCard({
 }) {
   const text = useText();
 
-  const goDetail = () => {
-    if (!onClickItem) return;
-    onClickItem(item.id);
-  };
-
   const handleCardClick = () => {
-    goDetail();
-  };
-
-  const handleViewDetailClick = (e: MouseEvent) => {
-    e.stopPropagation();
-    goDetail();
+    if (onClickItem) onClickItem(item.id);
   };
 
   const title = item.title;
-  const subtitle = item.subtitle ?? "";
-  const desc = item.displayDescription.trim();
 
-  const criteria = (item.criteria ?? []).slice(0, CRITERIA_MAX);
-  const hasMoreCriteria = (item.criteria?.length ?? 0) > CRITERIA_MAX;
   return (
     <BaseCard onClick={handleCardClick}>
-      <div className="flex h-full flex-col">
-        <div className="relative overflow-hidden rounded-2xl">
-          {item.thumbnailUrl ? (
-            <img
-              src={item.thumbnailUrl}
-              alt={item.thumbnailUrl ?? title}
-              referrerPolicy="no-referrer"
-              loading="lazy"
-              className="h-56 w-full object-cover sm:h-64 lg:h-72 transition-transform duration-300 group-hover:scale-105"
-            />
-          ) : (
-            <div className="grid h-56 w-full place-items-center bg-zinc-100 text-sm text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 sm:h-64 lg:h-72">
-              {text.noImage}
-            </div>
-          )}
-
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/65 via-black/20 to-transparent" />
-
-          {item.isEndangered && (
-            <div className="absolute right-3 bottom-3">
-              <span className="inline-flex items-center rounded-md bg-red-600 px-2 py-1 text-xs font-bold text-white shadow-sm">
-                {text.danger}
+      <div className="relative h-64 overflow-hidden rounded-2xl sm:h-72 lg:h-80">
+        {item.thumbnailUrl ? (
+          <img
+            src={item.thumbnailUrl}
+            alt={title}
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-indigo-50 to-zinc-100 dark:from-indigo-950 dark:to-zinc-800">
+            <div className="flex flex-col items-center gap-3">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-14 w-14 text-indigo-200 dark:text-indigo-800"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+              </svg>
+              <span className="line-clamp-2 px-4 text-center text-xs font-medium text-zinc-400 dark:text-zinc-500">
+                {title}
               </span>
             </div>
-          )}
-
-          <div className="absolute inset-x-0 bottom-0 p-4">
-            <h3 className="text-white text-lg font-semibold break-words leading-snug line-clamp-2">
-              {title}
-            </h3>
-            {subtitle && <p className="mt-0.5 text-sm text-white/80 line-clamp-1">{subtitle}</p>}
           </div>
-        </div>
+        )}
 
-        <div className="flex flex-1 flex-col space-y-4 px-4 py-4">
-          <div className="space-y-2">
-            {item.category && (
-              <div className="flex flex-col gap-1">
-                <span className="text-[10px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 font-bold">
-                  {text.heritageCategory}
-                </span>
-                <div>
-                  <TagChip>{item.category}</TagChip>
-                </div>
-              </div>
-            )}
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
 
-            {criteria.length > 0 && (
-              <div className="flex flex-col gap-1">
-                <span className="text-[10px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 font-bold">
-                  {text.criteria}
-                </span>
-                <div className="flex flex-wrap gap-1.5">
-                  {criteria.map((c: CriteriaCode) => (
-                    <MetaChip key={c}>{c}</MetaChip>
-                  ))}
-                  {hasMoreCriteria && (
-                    <MetaChip>+{(item.criteria?.length ?? 0) - CRITERIA_MAX}</MetaChip>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-
-          {desc ? (
-            <p
-              className="text-sm leading-6 text-zinc-700 dark:text-zinc-200 line-clamp-2"
-              style={{ WebkitLineClamp: DESC_CLAMP }}
-            >
-              {desc}
-            </p>
-          ) : (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">{text.noOverview}</p>
-          )}
-          <div className="mt-auto flex items-center justify-between pt-2 border-t border-zinc-100 dark:border-zinc-800">
-            <span className="text-xs text-zinc-500 dark:text-zinc-400" aria-hidden="true">
-              &nbsp;
+        {item.isEndangered && (
+          <div className="absolute right-3 top-3">
+            <span className="inline-flex items-center rounded-md bg-red-600 px-2 py-1 text-xs font-bold text-white shadow-sm">
+              {text.danger}
             </span>
-            <button
-              type="button"
-              onClick={handleViewDetailClick}
-              className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-            >
-              {text.viewDetails} <span>→</span>
-            </button>
           </div>
+        )}
+
+        <div className="absolute inset-x-0 bottom-0 p-4">
+          <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-white break-words">
+            {title}
+          </h3>
+          <p className="mt-1 text-sm text-white/70">
+            {item.country} · {item.yearInscribed}
+          </p>
         </div>
       </div>
     </BaseCard>

--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -73,7 +73,7 @@ export function HeritageCard({
               alt={item.thumbnailUrl ?? title}
               referrerPolicy="no-referrer"
               loading="lazy"
-              className="h-56 w-full object-cover sm:h-64 lg:h-72"
+              className="h-56 w-full object-cover sm:h-64 lg:h-72 transition-transform duration-300 group-hover:scale-105"
             />
           ) : (
             <div className="grid h-56 w-full place-items-center bg-zinc-100 text-sm text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 sm:h-64 lg:h-72">

--- a/client/src/shared/uis/BaseCard.tsx
+++ b/client/src/shared/uis/BaseCard.tsx
@@ -24,11 +24,14 @@ export function BaseCard({
 
   return (
     <Wrapper
-      className="
+      className={`
         group h-full overflow-hidden rounded-2xl border border-zinc-200/70
-        bg-white/70 shadow-sm backdrop-blur transition hover:shadow-md
+        bg-white/70 shadow-sm backdrop-blur
+        transition-all duration-200
+        hover:shadow-xl hover:-translate-y-1
         dark:border-zinc-800 dark:bg-zinc-900/70
-      "
+        ${isInteractive ? "cursor-pointer" : ""}
+      `}
       {...(isInteractive ? { role: "button", tabIndex: 0, onClick, onKeyDown: handleKeyDown } : {})}
     >
       {children}


### PR DESCRIPTION
## Summary

- Removes the text area below the image — card is now a full-height photo
- Gradient overlay (`from-black/80`) with title + `country · year` overlaid at the bottom
- Endangered badge repositioned to top-right corner
- No-image fallback: indigo gradient + globe SVG icon + title text
- Hover zoom animation included (from #349)

## Test plan

- [ ] Cards render with thumbnail image — photo fills card, gradient overlay visible
- [ ] Title and `country · year` visible at bottom overlay
- [ ] No-image fallback renders with gradient + globe icon
- [ ] Hover zoom animation works
- [ ] Endangered badge shows in top-right for endangered sites
- [ ] Card click navigates to detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)