### PR TITLE
feat(detail): collapse search form by default with trigger button [closes #356]

### DIFF
--- a/client/src/app/features/top/components/HeritageSubHeader.tsx
+++ b/client/src/app/features/top/components/HeritageSubHeader.tsx
@@ -5,9 +5,10 @@ type Props = {
   value: SearchValues;
   onSubmit: (q: Partial<SearchValues>) => void;
   onChange?: (v: SearchValues) => void;
+  onClose?: () => void;
 };
 
-export function HeritageSubHeader({ value, onSubmit, onChange }: Props) {
+export function HeritageSubHeader({ value, onSubmit, onChange, onClose }: Props) {
   return (
     <div className="z-30 border-zinc-200/70 bg-white/95 backdrop-blur">
       <div className="mx-auto w-full max-w-6xl px-4 py-3">
@@ -15,6 +16,28 @@ export function HeritageSubHeader({ value, onSubmit, onChange }: Props) {
           <div className="w-full md:w-[1000px]">
             <HeritageSearchForm value={value} onChange={onChange} onSubmit={onSubmit} />
           </div>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close search"
+              className="self-start rounded-full p-1.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800 md:self-center"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5"
+                aria-hidden="true"
+              >
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -96,6 +96,7 @@ function KeyExamInfo({ item }: { item: WorldHeritageDetailVm }) {
 
 export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) {
   const [search, setSearch] = useState<SearchValues>(DEFAULT_SEARCH);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const setLabel = useSetBreadcrumbLabel();
   const navigate = useNavigate();
   const text = useText();
@@ -129,7 +130,40 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
 
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900">
-      <HeritageSubHeader value={search} onChange={setSearch} onSubmit={handleSubmit} />
+      {isSearchOpen ? (
+        <HeritageSubHeader
+          value={search}
+          onChange={setSearch}
+          onSubmit={handleSubmit}
+          onClose={() => setIsSearchOpen(false)}
+        />
+      ) : (
+        <div className="border-b border-zinc-200/70 bg-white/95 backdrop-blur">
+          <div className="mx-auto w-full max-w-6xl px-4 py-2">
+            <button
+              type="button"
+              onClick={() => setIsSearchOpen(true)}
+              className="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold text-indigo-600 hover:bg-indigo-50 transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.35-4.35" />
+              </svg>
+              {text.searchOtherSites}
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="mx-auto w-full max-w-6xl px-4 mt-6 md:mt-8">
         <HeritageDetailTabs items={tabs} />

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -57,5 +57,6 @@
   "exploreRegions": "Explore by Region",
   "heroHeadline": "1,100+ UNESCO World Heritage Sites",
   "heroSubheadline": "Search and compare sites from across the globe.",
-  "heroCtaLabel": "Start Exploring"
+  "heroCtaLabel": "Start Exploring",
+  "searchOtherSites": "Search other sites"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -57,5 +57,6 @@
   "exploreRegions": "地域から探す",
   "heroHeadline": "ユネスコ世界遺産1,100件以上",
   "heroSubheadline": "世界中の遺産を検索・比較しよう。",
-  "heroCtaLabel": "探索を始める"
+  "heroCtaLabel": "探索を始める",
+  "searchOtherSites": "他の遺産を検索"
 }


### PR DESCRIPTION
## Summary
- Search form is now **hidden by default** on the heritage detail page
- Compact trigger button ("🔍 Search other sites") appears in its place
- Clicking the trigger opens the full `HeritageSubHeader`
- Clicking ✕ inside the header closes it again
- i18n key `searchOtherSites` added to both EN and JA locale files

## Test plan
- [ ] Detail page loads with search form hidden
- [ ] "Search other sites" button is visible and clearly labeled
- [ ] Clicking trigger opens the full search form
- [ ] Clicking ✕ closes the form
- [ ] Search submits correctly and navigates to results

🤖 Generated with [Claude Code](https://claude.com/claude-code)