### PR TITLE
chore(search): remove SearchResultMapComponent from SearchResultsPage [closes #362]

### DIFF
--- a/client/src/app/features/search/components/SearchResultsPage.tsx
+++ b/client/src/app/features/search/components/SearchResultsPage.tsx
@@ -6,7 +6,6 @@ import type {
 import { HeritageCard } from "@features/top/cards/HeritageCard";
 import { Pagination } from "@features/top/components/Pagination.tsx";
 import { BreadcrumbList } from "@shared/components/BreadcrumbList.tsx";
-import { SearchResultMapComponent } from "@features/search/components/SearchResultMapComponent.tsx";
 import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
 
@@ -86,8 +85,6 @@ export default function SearchResultsPage({
 
       <div className="pt-8">
         <BreadcrumbList />
-
-        <SearchResultMapComponent items={items} />
 
         {items.length === 0 ? (
           <div className="py-20 text-center">


### PR DESCRIPTION
## Summary
- Removes `<SearchResultMapComponent>` usage from `SearchResultsPage`
- Removes the now-unused import

## Why
Map's purpose was unclear to users (review feedback). The list of cards is the primary interface for the exam-study use case.

## Test plan
- [ ] Search results page renders without the map
- [ ] No console errors or TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)