### PR TITLE
perf: add stale-while-revalidate in-memory cache for heritage API calls [closes #333]

### DIFF
--- a/client/src/app/features/search/hooks/use-search-heritage-query.ts
+++ b/client/src/app/features/search/hooks/use-search-heritage-query.ts
@@ -3,6 +3,9 @@ import type { HeritageSearchParams } from "../../../../domain/types.ts";
 import { fetchSearchHeritagesResult } from "../apis";
 import type { SearchParams } from "../apis/search-api";
 import type { ApiWorldHeritageDto, ListResult } from "../../../../domain/types";
+import { getCached, setCached } from "@shared/cache/api-cache.ts";
+
+const CACHE_MAX_AGE_MS = 60_000;
 
 const isAbortError = (e: unknown): boolean => {
   return e instanceof DOMException && e.name === "AbortError";
@@ -44,12 +47,20 @@ export function useHeritageSearchQuery(
     }
 
     const abortController = new AbortController();
+    const cacheKey = `search:${JSON.stringify(request)}`;
+    const cached = getCached<ListResult<ApiWorldHeritageDto>>(cacheKey, CACHE_MAX_AGE_MS);
 
-    setLoading(true);
+    if (cached) {
+      setData(cached);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
     setError(null);
 
     fetchSearchHeritagesResult(request, { signal: abortController.signal })
       .then((res) => {
+        setCached(cacheKey, res);
         setData(res);
       })
       .catch((e: unknown) => {

--- a/client/src/app/features/top/hooks/use-top-page.ts
+++ b/client/src/app/features/top/hooks/use-top-page.ts
@@ -10,6 +10,9 @@ import type {
 } from "../../../../domain/types";
 import { fetchTopPage } from "@features/top/apis";
 import { useLocale } from "@shared/locale/LocaleHooks.ts";
+import { getCached, setCached } from "@shared/cache/api-cache.ts";
+
+const CACHE_MAX_AGE_MS = 60_000;
 
 type State = {
   data: WorldHeritageVm[];
@@ -67,11 +70,22 @@ export function useTopPage(args: { currentPage: number; perPage: number; order?:
       const abortController = new AbortController();
       abortRef.current = abortController;
 
-      setState((prev) => ({
-        ...prev,
-        loading: true,
-        error: null,
-      }));
+      const cacheKey = `top:${targetPage}:${targetPerPage}:${targetOrder}:${locale}`;
+      const cached = getCached<{ vmList: WorldHeritageVm[]; pagination: Pagination }>(
+        cacheKey,
+        CACHE_MAX_AGE_MS,
+      );
+
+      if (cached) {
+        setState({
+          data: cached.vmList,
+          pagination: cached.pagination,
+          loading: false,
+          error: null,
+        });
+      } else {
+        setState((prev) => ({ ...prev, loading: true, error: null }));
+      }
 
       fetchTopPage({
         currentPage: targetPage,
@@ -84,13 +98,9 @@ export function useTopPage(args: { currentPage: number; perPage: number; order?:
           if (abortController.signal.aborted) return;
 
           const vmList = toWorldHeritageListVm(res.items, locale);
+          setCached(cacheKey, { vmList, pagination: res.pagination });
 
-          setState({
-            data: vmList,
-            pagination: res.pagination,
-            loading: false,
-            error: null,
-          });
+          setState({ data: vmList, pagination: res.pagination, loading: false, error: null });
         })
         .catch((e: unknown) => {
           if (!mountedRef.current) return;
@@ -104,11 +114,7 @@ export function useTopPage(args: { currentPage: number; perPage: number; order?:
             return;
           }
 
-          setState((prev) => ({
-            ...prev,
-            loading: false,
-            error: e,
-          }));
+          setState((prev) => ({ ...prev, loading: false, error: e }));
         });
     },
     [locale],

--- a/client/src/shared/cache/api-cache.ts
+++ b/client/src/shared/cache/api-cache.ts
@@ -1,0 +1,13 @@
+type Entry<T> = { data: T; at: number };
+
+const store = new Map<string, Entry<unknown>>();
+
+export function getCached<T>(key: string, maxAgeMs: number): T | null {
+  const entry = store.get(key) as Entry<T> | undefined;
+  if (!entry || Date.now() - entry.at > maxAgeMs) return null;
+  return entry.data;
+}
+
+export function setCached<T>(key: string, data: T): void {
+  store.set(key, { data, at: Date.now() });
+}


### PR DESCRIPTION
## Summary
- New `src/shared/cache/api-cache.ts`: lightweight module-level get/set with 60s TTL
- `useTopPage`: serves cached data immediately (no spinner), revalidates in background
- `useHeritageSearchQuery`: same SWR pattern keyed by serialized search params
- No new npm dependencies

## Test plan
- [ ] Navigate to top page → navigate away → navigate back: no loading spinner, instant render
- [ ] Same for search results page
- [ ] After 60s, next navigation triggers a fresh fetch
- [ ] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)