### PR TITLE
perf: optimize above-fold image loading [closes #332]

### DIFF
--- a/client/src/app/features/search/components/SearchResultsPage.tsx
+++ b/client/src/app/features/search/components/SearchResultsPage.tsx
@@ -92,9 +92,9 @@ export default function SearchResultsPage({
           </div>
         ) : (
           <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((it) => (
+            {items.map((it, index) => (
               <li key={it.id} className="list-none">
-                <HeritageCard item={it} onClickItem={onClickItem} />
+                <HeritageCard item={it} onClickItem={onClickItem} isPriority={index < 3} />
               </li>
             ))}
           </ul>

--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -5,9 +5,11 @@ import { useText } from "@shared/locale/ui-text.ts";
 export function HeritageCard({
   item,
   onClickItem,
+  isPriority = false,
 }: {
   item: WorldHeritageVm;
   onClickItem?: (id: number) => void;
+  isPriority?: boolean;
 }) {
   const text = useText();
 
@@ -25,7 +27,11 @@ export function HeritageCard({
             src={item.thumbnailUrl}
             alt={title}
             referrerPolicy="no-referrer"
-            loading="lazy"
+            loading={isPriority ? "eager" : "lazy"}
+            fetchPriority={isPriority ? "high" : "auto"}
+            decoding="async"
+            width={400}
+            height={320}
             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
         ) : (

--- a/client/src/app/features/top/components/HeritageList.tsx
+++ b/client/src/app/features/top/components/HeritageList.tsx
@@ -18,9 +18,9 @@ export function HeritageList({
 
   return (
     <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
-      {items.map((it) => (
+      {items.map((it, index) => (
         <li key={it.id} className="list-none">
-          <HeritageCard item={it} onClickItem={onClickItem} />
+          <HeritageCard item={it} onClickItem={onClickItem} isPriority={index < 3} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- `HeritageCard`: add `isPriority` prop — first 3 cards get `loading="eager"` + `fetchPriority="high"`; rest stay `loading="lazy"`
- Add `width={400} height={320}` and `decoding="async"` to all card images to prevent CLS
- `HeritageList` + `SearchResultsPage`: pass `isPriority={index < 3}`

## Test plan
- [ ] First 3 cards load eagerly (check Network tab — no `loading=lazy` on first 3 images)
- [ ] No layout shift when images load in
- [ ] Below-fold images still lazy-load
- [ ] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)