### PR TITLE
fix(env): add .env.example with VITE_API_BASE_URL

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8700


### PR DESCRIPTION
## Summary

- `.env.example` を追加し、バックエンドプロキシ用の `VITE_API_BASE_URL` が必要であることをドキュメント化
- `.env.local` / `.env.production` は `.gitignore` 対象のため、開発者が `.env.example` をコピーしてローカル環境を構築できるようにする

## Test plan

- [ ] `cp .env.example .env.local` でローカル環境を構築できることを確認
- [ ] `import.meta.env.VITE_API_BASE_URL` が `undefined` にならないことを確認

## 関連

Closes #375
Part of #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)