### PR TITLE
feat: enlarge gallery images in a Lightbox with prev/next navigation

### DIFF
--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -1,10 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import type {
-  WorldHeritageDetailVm,
-  WorldHeritageImageVm,
-  SearchValues,
-} from "../../../../../domain/types.ts";
+import type { WorldHeritageDetailVm, SearchValues } from "../../../../../domain/types.ts";
 import { HeritageSubHeader } from "../HeritageSubHeader.tsx";
 import { HeritageHero } from "./HeritageHero";
 import { HeritageOverViewSection } from "./HeritageOverviewSection";
@@ -102,10 +98,7 @@ function KeyExamInfo({ item }: { item: WorldHeritageDetailVm }) {
 export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) {
   const [search, setSearch] = useState<SearchValues>(DEFAULT_SEARCH);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [lightboxImage, setLightboxImage] = useState<Pick<
-    WorldHeritageImageVm,
-    "id" | "url" | "alt" | "credit"
-  > | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const setLabel = useSetBreadcrumbLabel();
   const navigate = useNavigate();
   const text = useText();
@@ -198,7 +191,7 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
           {/* Left: Overview → Gallery */}
           <div className="space-y-8" id="content">
             <HeritageOverViewSection item={item} />
-            <HeritageGallery images={item.images} onSelectImage={setLightboxImage} />
+            <HeritageGallery images={item.images} onSelectImage={setLightboxIndex} />
           </div>
 
           {/* Right: Sidebar (PC only) */}
@@ -208,7 +201,12 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
         </div>
       </main>
 
-      <Lightbox image={lightboxImage} onClose={() => setLightboxImage(null)} />
+      <Lightbox
+        images={item.images}
+        index={lightboxIndex}
+        onClose={() => setLightboxIndex(null)}
+        onNavigate={setLightboxIndex}
+      />
     </div>
   );
 }

--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import type { WorldHeritageDetailVm, SearchValues } from "../../../../../domain/types.ts";
+import type {
+  WorldHeritageDetailVm,
+  WorldHeritageImageVm,
+  SearchValues,
+} from "../../../../../domain/types.ts";
 import { HeritageSubHeader } from "../HeritageSubHeader.tsx";
 import { HeritageHero } from "./HeritageHero";
 import { HeritageOverViewSection } from "./HeritageOverviewSection";
 import { HeritageSidebar } from "./HeritageSidebar";
 import { HeritageGallery } from "./HeritageGallery";
+import { Lightbox } from "@shared/uis/Lightbox.tsx";
 import { DetailHeritageMap } from "@features/top/components/heritage-detail/DetailHeritageMap.tsx";
 import { textType } from "@shared/styles/typography";
 import { useSetBreadcrumbLabel } from "@features/breadcrumbs/BreadCrumbHooks.ts";
@@ -97,6 +102,10 @@ function KeyExamInfo({ item }: { item: WorldHeritageDetailVm }) {
 export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) {
   const [search, setSearch] = useState<SearchValues>(DEFAULT_SEARCH);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [lightboxImage, setLightboxImage] = useState<Pick<
+    WorldHeritageImageVm,
+    "id" | "url" | "alt" | "credit"
+  > | null>(null);
   const setLabel = useSetBreadcrumbLabel();
   const navigate = useNavigate();
   const text = useText();
@@ -189,7 +198,7 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
           {/* Left: Overview → Gallery */}
           <div className="space-y-8" id="content">
             <HeritageOverViewSection item={item} />
-            <HeritageGallery images={item.images} />
+            <HeritageGallery images={item.images} onSelectImage={setLightboxImage} />
           </div>
 
           {/* Right: Sidebar (PC only) */}
@@ -198,6 +207,8 @@ export function HeritageDetailLayout({ item }: { item: WorldHeritageDetailVm }) 
           </div>
         </div>
       </main>
+
+      <Lightbox image={lightboxImage} onClose={() => setLightboxImage(null)} />
     </div>
   );
 }

--- a/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageDetailLayout.tsx
@@ -10,7 +10,7 @@ import { HeritageHero } from "./HeritageHero";
 import { HeritageOverViewSection } from "./HeritageOverviewSection";
 import { HeritageSidebar } from "./HeritageSidebar";
 import { HeritageGallery } from "./HeritageGallery";
-import { Lightbox } from "@shared/uis/Lightbox.tsx";
+import { Lightbox } from "./Lightbox.tsx";
 import { DetailHeritageMap } from "@features/top/components/heritage-detail/DetailHeritageMap.tsx";
 import { textType } from "@shared/styles/typography";
 import { useSetBreadcrumbLabel } from "@features/breadcrumbs/BreadCrumbHooks.ts";

--- a/client/src/app/features/top/components/heritage-detail/HeritageGallery.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageGallery.tsx
@@ -10,7 +10,7 @@ export function HeritageGallery({
   images: WorldHeritageImageVm[];
   previewCount?: number;
   onOpenGallery?: () => void;
-  onSelectImage?: (img: Pick<WorldHeritageImageVm, "id" | "url" | "alt" | "credit">) => void;
+  onSelectImage?: (index: number) => void;
 }) {
   if (!images?.length) return null;
 
@@ -44,13 +44,11 @@ export function HeritageGallery({
       </div>
 
       <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
-        {preview.map((img) => (
+        {preview.map((img, index) => (
           <button
             key={img.id}
             type="button"
-            onClick={() =>
-              onSelectImage?.({ id: img.id, url: img.url, alt: img.alt, credit: img.credit })
-            }
+            onClick={() => onSelectImage?.(index)}
             className="group text-left"
             aria-label={img.alt ? `Open photo: ${img.alt}` : "Open photo"}
             title={img.alt ?? "Open photo"}

--- a/client/src/app/features/top/components/heritage-detail/Lightbox.tsx
+++ b/client/src/app/features/top/components/heritage-detail/Lightbox.tsx
@@ -1,20 +1,38 @@
 import { useEffect } from "react";
 import CloseIcon from "@mui/icons-material/Close";
+import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import IconButton from "@shared/uis/Icon-Button.tsx";
 import type { WorldHeritageImageVm } from "../../../../../domain/types.ts";
 
 type LightboxImage = Pick<WorldHeritageImageVm, "id" | "url" | "alt" | "credit">;
 
-export function Lightbox({ image, onClose }: { image: LightboxImage | null; onClose: () => void }) {
+export function Lightbox({
+  images,
+  index,
+  onClose,
+  onNavigate,
+}: {
+  images: LightboxImage[];
+  index: number | null;
+  onClose: () => void;
+  onNavigate: (index: number) => void;
+}) {
+  const image = index !== null ? images[index] : null;
+  const hasPrev = index !== null && index > 0;
+  const hasNext = index !== null && index < images.length - 1;
+
   useEffect(() => {
     if (!image) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
+      if (e.key === "ArrowLeft" && hasPrev) onNavigate(index! - 1);
+      if (e.key === "ArrowRight" && hasNext) onNavigate(index! + 1);
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [image, onClose]);
+  }, [image, index, hasPrev, hasNext, onClose, onNavigate]);
 
   if (!image) return null;
 
@@ -32,6 +50,32 @@ export function Lightbox({ image, onClose }: { image: LightboxImage | null; onCl
       >
         <CloseIcon />
       </IconButton>
+
+      {hasPrev && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onNavigate(index! - 1);
+          }}
+          aria-label="Previous photo"
+          className="!absolute !left-4 !top-1/2 !-translate-y-1/2 !text-white"
+        >
+          <NavigateBeforeIcon />
+        </IconButton>
+      )}
+
+      {hasNext && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onNavigate(index! + 1);
+          }}
+          aria-label="Next photo"
+          className="!absolute !right-4 !top-1/2 !-translate-y-1/2 !text-white"
+        >
+          <NavigateNextIcon />
+        </IconButton>
+      )}
 
       <figure className="max-h-full max-w-full" onClick={(e) => e.stopPropagation()}>
         <img

--- a/client/src/app/features/top/components/heritage-detail/Lightbox.tsx
+++ b/client/src/app/features/top/components/heritage-detail/Lightbox.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import CloseIcon from "@mui/icons-material/Close";
-import IconButton from "./Icon-Button.tsx";
-import type { WorldHeritageImageVm } from "../../domain/types.ts";
+import IconButton from "@shared/uis/Icon-Button.tsx";
+import type { WorldHeritageImageVm } from "../../../../../domain/types.ts";
 
 type LightboxImage = Pick<WorldHeritageImageVm, "id" | "url" | "alt" | "credit">;
 

--- a/client/src/shared/uis/Lightbox.tsx
+++ b/client/src/shared/uis/Lightbox.tsx
@@ -1,0 +1,25 @@
+import CloseIcon from "@mui/icons-material/Close";
+import IconButton from "./Icon-Button.tsx";
+import type { WorldHeritageImageVm } from "../../domain/types.ts";
+
+type LightboxImage = Pick<WorldHeritageImageVm, "id" | "url" | "alt" | "credit">;
+
+export function Lightbox({ image, onClose }: { image: LightboxImage | null; onClose: () => void }) {
+  if (!image) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+    >
+      <IconButton
+        onClick={onClose}
+        aria-label="Close"
+        className="!absolute !right-4 !top-4 !text-white"
+      >
+        <CloseIcon />
+      </IconButton>
+    </div>
+  );
+}

--- a/client/src/shared/uis/Lightbox.tsx
+++ b/client/src/shared/uis/Lightbox.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import CloseIcon from "@mui/icons-material/Close";
 import IconButton from "./Icon-Button.tsx";
 import type { WorldHeritageImageVm } from "../../domain/types.ts";
@@ -5,12 +6,23 @@ import type { WorldHeritageImageVm } from "../../domain/types.ts";
 type LightboxImage = Pick<WorldHeritageImageVm, "id" | "url" | "alt" | "credit">;
 
 export function Lightbox({ image, onClose }: { image: LightboxImage | null; onClose: () => void }) {
+  useEffect(() => {
+    if (!image) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [image, onClose]);
+
   if (!image) return null;
 
   return (
     <div
       role="dialog"
       aria-modal="true"
+      onClick={onClose}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
     >
       <IconButton
@@ -21,7 +33,7 @@ export function Lightbox({ image, onClose }: { image: LightboxImage | null; onCl
         <CloseIcon />
       </IconButton>
 
-      <figure className="max-h-full max-w-full">
+      <figure className="max-h-full max-w-full" onClick={(e) => e.stopPropagation()}>
         <img
           src={image.url}
           alt={image.alt ?? ""}

--- a/client/src/shared/uis/Lightbox.tsx
+++ b/client/src/shared/uis/Lightbox.tsx
@@ -20,6 +20,20 @@ export function Lightbox({ image, onClose }: { image: LightboxImage | null; onCl
       >
         <CloseIcon />
       </IconButton>
+
+      <figure className="max-h-full max-w-full">
+        <img
+          src={image.url}
+          alt={image.alt ?? ""}
+          referrerPolicy="no-referrer"
+          className="max-h-[85vh] max-w-full rounded-lg object-contain"
+        />
+        {image.credit && (
+          <figcaption className="mt-2 text-center text-sm text-zinc-300">
+            © {image.credit}
+          </figcaption>
+        )}
+      </figure>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a Lightbox component (overlay + close button) for enlarging gallery images, scoped to the heritage-detail feature since it's only used there
- Wire `HeritageGallery`'s thumbnail click to open the Lightbox on the clicked image
- Support closing via Escape key or clicking the overlay backdrop
- Add prev/next navigation (on-screen arrows + Left/Right arrow keys) to move between gallery images without closing the Lightbox

Closes #391 (supersedes #142, #144 — pivoted from hero-image-swap to a Lightbox enlarge pattern)

## Test plan
- [ ] Click a gallery thumbnail on a heritage detail page and confirm it opens enlarged in the Lightbox
- [ ] Confirm Escape key and clicking outside the image close the Lightbox
- [ ] Confirm left/right arrows appear correctly (no left arrow on first image, no right arrow on last image) and navigate between images
- [ ] Confirm Left/Right arrow keys also navigate