### PR TITLE
feat: add dedicated criteria detail page at /heritages/criteria/:code

### DIFF
--- a/client/src/app/features/top/components/heritage-detail/criteria/CriteriaDetailPage.tsx
+++ b/client/src/app/features/top/components/heritage-detail/criteria/CriteriaDetailPage.tsx
@@ -1,0 +1,61 @@
+import type { WorldHeritageVm } from "../../../../../../domain/types.ts";
+import { CriteriaExampleCard } from "./CriteriaExampleCard";
+import { useText } from "@shared/locale/ui-text.ts";
+
+export function CriteriaDetailPage({
+  code,
+  title,
+  description,
+  sourceUrl,
+  items,
+  onClickItem,
+  onViewAllResults,
+}: {
+  code: string;
+  title: string;
+  description: string;
+  sourceUrl: string;
+  items: ReadonlyArray<WorldHeritageVm>;
+  onClickItem: (id: number) => void;
+  onViewAllResults: () => void;
+}) {
+  const text = useText();
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-12">
+      <header className="mb-8">
+        <p className="text-sm font-medium uppercase tracking-wide text-zinc-500">
+          {text.criteria} ({code})
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold">{title}</h1>
+        <p className="mt-3 max-w-2xl text-zinc-700">{description}</p>
+        <a
+          href={sourceUrl}
+          referrerPolicy="no-referrer"
+          className="mt-2 inline-block text-sm text-blue-600 hover:underline"
+        >
+          {text.unescoCriteriaSource}
+        </a>
+      </header>
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-medium">{text.exampleSites}</h2>
+          <button onClick={onViewAllResults} className="text-sm text-blue-600 hover:underline">
+            {text.viewAllResults}
+          </button>
+        </div>
+
+        {items.length === 0 ? (
+          <p className="text-sm text-zinc-600">{text.noSitesFound}</p>
+        ) : (
+          <ul className="grid list-none grid-cols-1 gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((item) => (
+              <CriteriaExampleCard key={item.id} item={item} onClickItem={onClickItem} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/client/src/app/features/top/components/heritage-detail/criteria/CriteriaExampleCard.tsx
+++ b/client/src/app/features/top/components/heritage-detail/criteria/CriteriaExampleCard.tsx
@@ -1,0 +1,46 @@
+import type { WorldHeritageVm } from "../../../../../../domain/types.ts";
+import { CriteriaTags } from "@shared/uis/CriteriaTags.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import { useLocale } from "@shared/locale/LocaleHooks.ts";
+
+export function CriteriaExampleCard({
+  item,
+  onClickItem,
+}: {
+  item: WorldHeritageVm;
+  onClickItem: (id: number) => void;
+}) {
+  const text = useText();
+  const { locale } = useLocale();
+
+  const metadataLine = [
+    text.region,
+    text.regionLabels[item.region] ?? "—",
+    "/",
+    text.country,
+    item.country,
+    "/",
+    text.category,
+    text.categoryLabels[item.category] ?? "—",
+    "/",
+    text.yearInscribed,
+    item.yearInscribed,
+  ].join(" ");
+
+  return (
+    <li className="list-none rounded-2xl border border-zinc-200 bg-white/80 p-5 shadow-sm backdrop-blur">
+      <h3 className="text-lg font-semibold text-zinc-900">{item.title}</h3>
+      <p className="mt-2 line-clamp-3 text-sm text-zinc-600">{item.displayDescription}</p>
+      <p className="mt-3 text-xs text-zinc-500">{metadataLine}</p>
+      <div className="mt-3">
+        <CriteriaTags criteria={item.criteria} locale={locale} />
+      </div>
+      <button
+        onClick={() => onClickItem(item.id)}
+        className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+      >
+        {text.viewDetails}
+      </button>
+    </li>
+  );
+}

--- a/client/src/app/features/top/components/heritage-detail/criteria/__tests__/CriteriaDetailPage.test.tsx
+++ b/client/src/app/features/top/components/heritage-detail/criteria/__tests__/CriteriaDetailPage.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { CriteriaDetailPage } from "../CriteriaDetailPage";
+import type { WorldHeritageVm } from "../../../../../../../domain/types.ts";
+
+const buildVm = (overrides: Partial<WorldHeritageVm> = {}): WorldHeritageVm => ({
+  id: 1,
+  officialName: "Official",
+  name: "Tanbaly",
+  heritageNameJp: "タムガリ",
+  country: "Kazakhstan",
+  countryNameJp: "カザフスタン",
+  region: "Asia",
+  stateParty: "Kazakhstan",
+  category: "Cultural",
+  criteria: ["iii"],
+  yearInscribed: 2004,
+  areaHectares: null,
+  bufferZoneHectares: null,
+  isEndangered: false,
+  latitude: null,
+  longitude: null,
+  shortDescription: "dummy",
+  shortDescriptionJp: null,
+  unescoSiteUrl: null,
+  statePartyCodes: [],
+  statePartiesMeta: {},
+  primaryStatePartyCode: null,
+  thumbnailUrl: null,
+  title: "Tanbaly",
+  subtitle: "Kazakhstan · Asia",
+  displaySubName: null,
+  displayDescription: "Petroglyphs of the Archaeological Landscape of Tanbaly.",
+  areaText: "—",
+  bufferText: "—",
+  criteriaText: "(iii)",
+  images: [],
+  ...overrides,
+});
+
+const renderPage = (items: WorldHeritageVm[], onViewAllResults = jest.fn()) =>
+  render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <CriteriaDetailPage
+          code="iii"
+          title="文明の証拠"
+          description="現存する、または消滅した文化的伝統や文明の独自または稀有な証拠であること。"
+          sourceUrl="https://whc.unesco.org/en/criteria/#iii"
+          items={items}
+          onClickItem={jest.fn()}
+          onViewAllResults={onViewAllResults}
+        />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("CriteriaDetailPage", () => {
+  test("基準コード・タイトル・説明・UNESCO公式リンクを表示する", () => {
+    renderPage([buildVm()]);
+
+    expect(screen.getByText("Criteria (iii)")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "文明の証拠" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "現存する、または消滅した文化的伝統や文明の独自または稀有な証拠であること。",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "UNESCO official criteria page" })).toHaveAttribute(
+      "href",
+      "https://whc.unesco.org/en/criteria/#iii",
+    );
+  });
+
+  test("実例がある場合は遺産カードを表示する", () => {
+    renderPage([buildVm({ id: 1, title: "Tanbaly" }), buildVm({ id: 2, title: "Other Site" })]);
+
+    expect(screen.getByText("Tanbaly")).toBeInTheDocument();
+    expect(screen.getByText("Other Site")).toBeInTheDocument();
+  });
+
+  test("実例が0件の場合は該当なしメッセージを表示する", () => {
+    renderPage([]);
+
+    expect(screen.getByText("No sites found.")).toBeInTheDocument();
+  });
+
+  test("「すべての結果を見る」ボタンを押すと onViewAllResults が呼ばれる", () => {
+    const onViewAllResults = jest.fn();
+    renderPage([buildVm()], onViewAllResults);
+
+    fireEvent.click(screen.getByRole("button", { name: "View all results" }));
+
+    expect(onViewAllResults).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/app/features/top/components/heritage-detail/criteria/__tests__/CriteriaExampleCard.test.tsx
+++ b/client/src/app/features/top/components/heritage-detail/criteria/__tests__/CriteriaExampleCard.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { CriteriaExampleCard } from "../CriteriaExampleCard";
+import type { WorldHeritageVm } from "../../../../../../../domain/types.ts";
+
+const buildVm = (overrides: Partial<WorldHeritageVm> = {}): WorldHeritageVm => ({
+  id: 1,
+  officialName: "Official",
+  name: "Tanbaly",
+  heritageNameJp: "タムガリ",
+  country: "Kazakhstan",
+  countryNameJp: "カザフスタン",
+  region: "Asia",
+  stateParty: "Kazakhstan",
+  category: "Cultural",
+  criteria: ["iii"],
+  yearInscribed: 2004,
+  areaHectares: null,
+  bufferZoneHectares: null,
+  isEndangered: false,
+  latitude: null,
+  longitude: null,
+  shortDescription: "dummy",
+  shortDescriptionJp: null,
+  unescoSiteUrl: null,
+  statePartyCodes: [],
+  statePartiesMeta: {},
+  primaryStatePartyCode: null,
+  thumbnailUrl: null,
+  title: "Tanbaly",
+  subtitle: "Kazakhstan · Asia",
+  displaySubName: null,
+  displayDescription: "Petroglyphs of the Archaeological Landscape of Tanbaly.",
+  areaText: "—",
+  bufferText: "—",
+  criteriaText: "(iii)",
+  images: [],
+  ...overrides,
+});
+
+const renderCard = (item: WorldHeritageVm, onClickItem = jest.fn()) =>
+  render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <ul>
+          <CriteriaExampleCard item={item} onClickItem={onClickItem} />
+        </ul>
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("CriteriaExampleCard", () => {
+  test("名称・説明・メタ情報・基準タグを表示する", () => {
+    renderCard(buildVm());
+
+    expect(screen.getByText("Tanbaly")).toBeInTheDocument();
+    expect(
+      screen.getByText("Petroglyphs of the Archaeological Landscape of Tanbaly."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Asia/)).toBeInTheDocument();
+    expect(screen.getByText(/Kazakhstan/)).toBeInTheDocument();
+    expect(screen.getByText(/Cultural/)).toBeInTheDocument();
+    expect(screen.getByText(/2004/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /iii/ })).toBeInTheDocument();
+  });
+
+  test("詳細を見るボタンを押すと item.id で onClickItem が呼ばれる", () => {
+    const onClickItem = jest.fn();
+    renderCard(buildVm({ id: 42 }), onClickItem);
+
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
+
+    expect(onClickItem).toHaveBeenCalledWith(42);
+  });
+});

--- a/client/src/app/features/top/containers/__tests__/criteria-detail-container.test.tsx
+++ b/client/src/app/features/top/containers/__tests__/criteria-detail-container.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { CriteriaDetailContainer } from "../criteria-detail-container";
+import { useHeritageSearchQuery } from "@features/search/hooks/use-search-heritage-query";
+import type { ApiWorldHeritageDto, ListResult } from "../../../../../domain/types";
+
+jest.mock("@shared/locale/LocaleHooks", () => ({
+  __esModule: true,
+  useLocale: () => ({ locale: "en", setLocale: jest.fn(), toggleLocale: jest.fn() }),
+}));
+
+jest.mock("@features/search/hooks/use-search-heritage-query", () => ({
+  useHeritageSearchQuery: jest.fn(),
+}));
+
+jest.mock("../../components/heritage-detail/criteria/CriteriaDetailPage", () => ({
+  CriteriaDetailPage: ({ code, title }: { code: string; title: string }) => (
+    <div data-testid="criteria-detail-page">
+      Criteria page: {code} / {title}
+    </div>
+  ),
+}));
+
+const useHeritageSearchQueryMock = useHeritageSearchQuery as jest.MockedFunction<
+  typeof useHeritageSearchQuery
+>;
+
+type UseHeritageSearchQueryReturn = {
+  data: ListResult<ApiWorldHeritageDto> | null;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+};
+
+const mockReturn = (overrides: Partial<UseHeritageSearchQueryReturn> = {}) =>
+  useHeritageSearchQueryMock.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    ...overrides,
+  } as ReturnType<typeof useHeritageSearchQuery>);
+
+const renderWithRoute = (initialEntry: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/heritages" element={<div>Index Page</div>} />
+        <Route path="/heritages/criteria/:code" element={<CriteriaDetailContainer />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("CriteriaDetailContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReturn();
+  });
+
+  test("不正な基準コードの場合は一覧ページへリダイレクトする", async () => {
+    renderWithRoute("/heritages/criteria/zzz");
+
+    expect(await screen.findByText("Index Page")).toBeInTheDocument();
+  });
+
+  test("読み込み中は Spinner を表示する", () => {
+    mockReturn({ isLoading: true });
+
+    renderWithRoute("/heritages/criteria/iii");
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  test("エラー時は ErrorPanel を表示する", () => {
+    mockReturn({ error: new Error("boom") });
+
+    renderWithRoute("/heritages/criteria/iii");
+
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  test("成功時には criteria を渡して検索フックを呼び、CriteriaDetailPage を表示する", () => {
+    mockReturn({ data: { items: [], pagination: {} as never } });
+
+    renderWithRoute("/heritages/criteria/iii");
+
+    expect(screen.getByTestId("criteria-detail-page")).toHaveTextContent("Criteria page: iii");
+    expect(useHeritageSearchQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ criteria: ["iii"], per_page: 6 }),
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+});

--- a/client/src/app/features/top/containers/criteria-detail-container.tsx
+++ b/client/src/app/features/top/containers/criteria-detail-container.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  getCriteria,
+  isCriteriaCode,
+  UNESCO_CRITERIA_SOURCE_URL,
+} from "../../../../domain/criteria";
+import { useLocale } from "@shared/locale/LocaleHooks";
+import { useHeritageSearchQuery } from "@features/search/hooks/use-search-heritage-query";
+import { DEFAULT_HERITAGE_SEARCH_PARAMS } from "@features/search/mapper/search-heritage.types";
+import { toWorldHeritageListVm } from "@features/heritages/mappers/to-world-heritage-vm";
+import { CriteriaDetailPage } from "../components/heritage-detail/criteria/CriteriaDetailPage";
+import { Spinner } from "@shared/uis/Spinner.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+
+const EXAMPLE_COUNT = 6;
+
+export function CriteriaDetailContainer() {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const { locale } = useLocale();
+
+  useEffect(() => {
+    if (!code || !isCriteriaCode(code)) navigate("/heritages", { replace: true });
+  }, [code, navigate]);
+
+  const validCode = code && isCriteriaCode(code) ? code : null;
+
+  const { data, isLoading, error, refetch } = useHeritageSearchQuery(
+    {
+      ...DEFAULT_HERITAGE_SEARCH_PARAMS,
+      criteria: validCode ? [validCode] : [],
+      per_page: EXAMPLE_COUNT,
+    },
+    { enabled: validCode !== null },
+  );
+
+  if (!validCode) return null;
+
+  if (isLoading) return <Spinner />;
+
+  if (error) {
+    const message = error instanceof Error ? error.message : "Failed to load example sites.";
+    return <ErrorPanel message={message} onRetry={refetch} />;
+  }
+
+  const { title, description } = getCriteria(validCode, locale);
+  const items = data ? toWorldHeritageListVm(data.items, locale) : [];
+
+  return (
+    <CriteriaDetailPage
+      code={validCode}
+      title={title}
+      description={description}
+      sourceUrl={`${UNESCO_CRITERIA_SOURCE_URL}#${validCode}`}
+      items={items}
+      onClickItem={(id) => navigate(`/heritages/${id}`)}
+      onViewAllResults={() => navigate(`/heritages/results?criteria=${validCode}`)}
+    />
+  );
+}

--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 import TopPageContainer from "@features/top/containers/top-page-container.tsx";
 import { WorldHeritageDetailContainer } from "@features/top/containers/world-heritage-detail-container.tsx";
+import { CriteriaDetailContainer } from "@features/top/containers/criteria-detail-container.tsx";
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
@@ -14,6 +15,7 @@ export function AppRoutes() {
           <Routes>
             <Route path="/heritages" element={<TopPageContainer />} />
             <Route path="/heritages/results" element={<SearchHeritageResultsContainer />} />
+            <Route path="/heritages/criteria/:code" element={<CriteriaDetailContainer />} />
             <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
             <Route path="*" element={<Navigate to="/heritages" replace />} />
           </Routes>

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -58,5 +58,8 @@
   "heroHeadline": "1,100+ UNESCO World Heritage Sites",
   "heroSubheadline": "Search and compare sites from across the globe.",
   "heroCtaLabel": "Start Exploring",
-  "searchOtherSites": "Search other sites"
+  "searchOtherSites": "Search other sites",
+  "exampleSites": "Example sites",
+  "viewAllResults": "View all results",
+  "unescoCriteriaSource": "UNESCO official criteria page"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -58,5 +58,8 @@
   "heroHeadline": "ユネスコ世界遺産1,100件以上",
   "heroSubheadline": "世界中の遺産を検索・比較しよう。",
   "heroCtaLabel": "探索を始める",
-  "searchOtherSites": "他の遺産を検索"
+  "searchOtherSites": "他の遺産を検索",
+  "exampleSites": "実例",
+  "viewAllResults": "すべての結果を見る",
+  "unescoCriteriaSource": "UNESCO 公式の登録基準ページ"
 }

--- a/client/src/shared/uis/CriteriaTags.tsx
+++ b/client/src/shared/uis/CriteriaTags.tsx
@@ -1,9 +1,5 @@
-import {
-  getCriteria,
-  isCriteriaCode,
-  UNESCO_CRITERIA_SOURCE_URL,
-  type Locale,
-} from "../../domain/criteria";
+import { Link } from "react-router-dom";
+import { getCriteria, isCriteriaCode, type Locale } from "../../domain/criteria";
 import type { CriteriaCode } from "../../domain/types.ts";
 
 export function CriteriaTags({
@@ -23,19 +19,17 @@ export function CriteriaTags({
     <ul className="flex flex-wrap gap-2">
       {safeCriteria.map((code) => {
         const { title, description } = getCriteria(code, locale);
-        const href = `${UNESCO_CRITERIA_SOURCE_URL}#${code}`;
 
         return (
           <li key={code}>
-            <a
-              href={href}
-              referrerPolicy="no-referrer"
+            <Link
+              to={`/heritages/criteria/${code}`}
               title={description ? `${title} — ${description}` : title}
               className="inline-flex items-center rounded bg-gray-200 px-2 py-1 text-sm hover:bg-gray-300"
             >
               <span className="font-medium">{title || code}</span>
               <span className="ml-1 opacity-70">({code})</span>
-            </a>
+            </Link>
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- Add a dedicated, shareable page per UNESCO selection criterion (i–x) at `/heritages/criteria/:code`, since each code is an independent resource and deserves a path param rather than a query param.
- Page layout is modeled on pamon.sekaken.jp's heritage list cards: site name, description, region/country/category/year metadata line, criteria tags, and a detail link.
- `CriteriaTags` now links to this internal page instead of the external UNESCO source URL, so users can see real example sites without leaving the SPA.

## Changes
- `feat(i18n)`: add `exampleSites` / `viewAllResults` / `unescoCriteriaSource` ui-text keys
- `feat(criteria)`: add `CriteriaExampleCard` (single example site card)
- `feat(criteria)`: add `CriteriaDetailPage` (title/description + example grid + "view all results")
- `feat(criteria)`: add `CriteriaDetailContainer` (resolves `:code`, redirects invalid codes, fetches up to 6 example sites via the existing search query hook)
- `feat(routes)`: wire `/heritages/criteria/:code` into `AppRoutes`
- `refactor(criteria-tags)`: link criteria badges to the internal detail page instead of the external UNESCO link

Closes #399

## Test plan
- [x] `tsc --noEmit` passes
- [x] `jest` — 17 suites / 94 tests passing (10 new tests added for the criteria feature)
- [ ] Manually visit `/heritages/criteria/iii` (and an invalid code) in a browser to confirm rendering and the redirect behavior