### PR TITLE
feat(user): add UserCreateContainer and wire /users/new route

### DIFF
--- a/client/src/app/features/user/containers/__tests__/user-create-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-create-container.test.tsx
@@ -1,0 +1,105 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { CreateUserFormValues } from "../../types";
+import type { ApiUserDto } from "../../apis/user-api";
+
+const submitMock = jest.fn();
+const useCreateUserMock = jest.fn();
+
+jest.mock("../../hooks/use-create-user", () => ({
+  useCreateUser: () => useCreateUserMock(),
+}));
+
+jest.mock("../../components/UserCreateForm", () => ({
+  __esModule: true,
+  UserCreateForm: function MockUserCreateForm(props: {
+    value: CreateUserFormValues;
+    onChange: (next: CreateUserFormValues) => void;
+    onSubmit: () => void;
+    isLoading: boolean;
+    error: unknown;
+    createdUser: ApiUserDto | null;
+  }) {
+    return (
+      <div>
+        <span data-testid="first-name">{props.value.firstName}</span>
+        <span data-testid="is-loading">{String(props.isLoading)}</span>
+        <span data-testid="error">{props.error ? "has-error" : "no-error"}</span>
+        <span data-testid="created-user">{props.createdUser ? props.createdUser.email : ""}</span>
+        <button type="button" onClick={() => props.onChange({ ...props.value, firstName: "Taro" })}>
+          change
+        </button>
+        <button type="button" onClick={props.onSubmit}>
+          submit
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { UserCreateContainer } from "../user-create-container";
+
+describe("UserCreateContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCreateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("renders the form with the default draft values", () => {
+    render(<UserCreateContainer />);
+
+    expect(screen.getByTestId("first-name").textContent).toBe("");
+    expect(screen.getByTestId("is-loading").textContent).toBe("false");
+    expect(screen.getByTestId("error").textContent).toBe("no-error");
+  });
+
+  it("updates the draft when the form calls onChange", () => {
+    render(<UserCreateContainer />);
+
+    fireEvent.click(screen.getByRole("button", { name: "change" }));
+
+    expect(screen.getByTestId("first-name").textContent).toBe("Taro");
+  });
+
+  it("calls submit with the current draft when the form calls onSubmit", () => {
+    render(<UserCreateContainer />);
+
+    fireEvent.click(screen.getByRole("button", { name: "change" }));
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "Taro", lastName: "", email: "", password: "" }),
+    );
+  });
+
+  it("passes through isLoading, error, and createdUser from the hook", () => {
+    const createdUser: ApiUserDto = {
+      id: 1,
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      age_range: "teens",
+      subscription_tier: "free",
+      subscription_expires_at: null,
+    };
+    useCreateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: createdUser,
+      isLoading: true,
+      error: new Error("boom"),
+    });
+
+    render(<UserCreateContainer />);
+
+    expect(screen.getByTestId("is-loading").textContent).toBe("true");
+    expect(screen.getByTestId("error").textContent).toBe("has-error");
+    expect(screen.getByTestId("created-user").textContent).toBe("taro@example.com");
+  });
+});

--- a/client/src/app/features/user/containers/user-create-container.tsx
+++ b/client/src/app/features/user/containers/user-create-container.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+import { useCreateUser } from "../hooks/use-create-user";
+import { DEFAULT_CREATE_USER_FORM_VALUES } from "../mapper/user.types";
+import type { CreateUserFormValues } from "../types";
+import { UserCreateForm } from "../components/UserCreateForm";
+
+export function UserCreateContainer() {
+  const [draft, setDraft] = useState<CreateUserFormValues>(DEFAULT_CREATE_USER_FORM_VALUES);
+  const { submit, data, isLoading, error } = useCreateUser();
+
+  const handleChange = useCallback((next: CreateUserFormValues) => {
+    setDraft(next);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    void submit(draft);
+  }, [draft, submit]);
+
+  return (
+    <UserCreateForm
+      value={draft}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      error={error}
+      createdUser={data}
+    />
+  );
+}

--- a/client/src/app/features/user/mapper/user.types.ts
+++ b/client/src/app/features/user/mapper/user.types.ts
@@ -1,0 +1,11 @@
+import type { CreateUserFormValues } from "../types";
+
+export const DEFAULT_CREATE_USER_FORM_VALUES: CreateUserFormValues = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};

--- a/client/src/app/features/user/mapper/user.types.ts
+++ b/client/src/app/features/user/mapper/user.types.ts
@@ -5,7 +5,4 @@ export const DEFAULT_CREATE_USER_FORM_VALUES: CreateUserFormValues = {
   lastName: "",
   email: "",
   password: "",
-  ageRange: "teens",
-  subscriptionTier: "free",
-  subscriptionExpiresAt: null,
 };

--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { WorldHeritageDetailContainer } from "@features/top/containers/world-her
 import { CriteriaDetailContainer } from "@features/top/containers/criteria-detail-container.tsx";
 import { HeritageGalleryContainer } from "@features/top/containers/heritage-gallery-container.tsx";
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
+import { UserCreateContainer } from "@features/user/containers/user-create-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { AppLayout } from "@shared/layout/AppLayout.tsx";
@@ -19,6 +20,7 @@ export function AppRoutes() {
             <Route path="/heritages/criteria/:code" element={<CriteriaDetailContainer />} />
             <Route path="/heritages/:id/gallery" element={<HeritageGalleryContainer />} />
             <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
+            <Route path="/users/new" element={<UserCreateContainer />} />
             <Route path="*" element={<Navigate to="/heritages" replace />} />
           </Routes>
         </AppLayout>


### PR DESCRIPTION
## Summary
- Add `UserCreateContainer` holding form draft state and wiring it to `useCreateUser`
- Add `DEFAULT_CREATE_USER_FORM_VALUES` initial form state (name/email/password only)
- Wire `/users/new` route to `UserCreateContainer` in `AppRoutes`

Part of the `feat/user-ui-create` stack (5/5): type → mapper → hooks → ui-components → container.
Stacked on #431 — merge that first.

## Why this changed from the original PR
Originally this branch only had the container, and routing (`AppRoutes.tsx`) was in the ui-components branch (old #409, merged). That was backwards: the container imports `UserCreateForm` (which only existed in the ui-components branch stacked *above* this one), so `npm run build` failed on this PR. Route wiring depends on the container, so it's been moved here — the branches were reordered to hooks → ui-components → container, and route wiring now ships with the container that it depends on. See #431 for the corresponding ui-components PR.

Also rebased on top of #431's age-range/subscription removal (default form values updated to match the trimmed `CreateUserFormValues`).

## Test plan
- [x] `npm run typecheck` (verified locally, passes)