### PR TITLE
feat(user): add UserCreateForm UI component with i18n text

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { createUserApi } from "./user-api";
+import type { ApiCreateUserResponse, ApiUserDto, CreateUserRequest } from "./user-api";
+
+type MockResponse = Pick<Response, "ok" | "status" | "json">;
+
+let fetchSpy: jest.MockedFunction<typeof fetch>;
+
+const API_BASE = "http://localhost:8700";
+const ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/users`;
+
+const makeOkResponse = (body: ApiCreateUserResponse): MockResponse => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+const makeNgResponse = (status: number): MockResponse => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+});
+
+const makeRequest = (overrides: Partial<CreateUserRequest> = {}): CreateUserRequest => ({
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+  ...overrides,
+});
+
+const makeUserDto = (overrides: Partial<ApiUserDto> = {}): ApiUserDto => ({
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+  ...overrides,
+});
+
+describe("createUserApi", () => {
+  let api: ReturnType<typeof createUserApi>;
+
+  beforeEach(() => {
+    fetchSpy = jest.fn() as jest.MockedFunction<typeof fetch>;
+    api = createUserApi({ apiBase: API_BASE, fetchImpl: fetchSpy });
+  });
+
+  describe("createUser", () => {
+    it("posts the request body to the users endpoint", async () => {
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const request = makeRequest();
+      const out = await api.createUser(request);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(request),
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          }),
+          credentials: "omit",
+        }),
+      );
+      expect(out).toEqual(user);
+    });
+
+    it("trims trailing slash from apiBase", async () => {
+      const apiWithTrailingSlash = createUserApi({
+        apiBase: "http://localhost:8700/",
+        fetchImpl: fetchSpy,
+      });
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      await apiWithTrailingSlash.createUser(makeRequest());
+
+      expect(fetchSpy).toHaveBeenCalledWith(ENDPOINT, expect.objectContaining({ method: "POST" }));
+    });
+
+    it("merges headers and allows credentials and signal override", async () => {
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const ac = new AbortController();
+      await api.createUser(makeRequest(), {
+        headers: { "X-Trace": "t" },
+        credentials: "include",
+        signal: ac.signal,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "X-Trace": "t",
+          }),
+          credentials: "include",
+          signal: ac.signal,
+        }),
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(api.createUser(makeRequest())).rejects.toThrow("HTTP 422");
+    });
+
+    it("throws when API status is not success", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "error", data: { message: "invalid" } }) as Response,
+      );
+
+      await expect(api.createUser(makeRequest())).rejects.toThrow(
+        "API status is not success: error",
+      );
+    });
+  });
+
+  it("throws when apiBase is empty", () => {
+    expect(() => createUserApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
+      "apiBase is required",
+    );
+  });
+});

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -10,9 +10,6 @@ export type CreateUserRequest = {
   last_name: string;
   email: string;
   password: string;
-  age_range: AgeRange;
-  subscription_tier: SubscriptionTier;
-  subscription_expires_at: string | null;
 };
 
 export type ApiUserDto = {

--- a/client/src/app/features/user/components/UserCreateForm.tsx
+++ b/client/src/app/features/user/components/UserCreateForm.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+import type { FormEvent } from "react";
+import TextField from "@shared/uis/TextField.tsx";
+import Select from "@shared/uis/Select.tsx";
+import { Button } from "@shared/uis/Button.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import { AGE_RANGES, SUBSCRIPTION_TIERS } from "../types";
+import type { AgeRange, CreateUserFormValues, SubscriptionTier } from "../types";
+import type { ApiUserDto } from "../apis/user-api";
+
+type Props = {
+  value: CreateUserFormValues;
+  onChange: (next: CreateUserFormValues) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+  error: unknown;
+  createdUser: ApiUserDto | null;
+};
+
+export function UserCreateForm({
+  value,
+  onChange,
+  onSubmit,
+  isLoading,
+  error,
+  createdUser,
+}: Props) {
+  const text = useText();
+
+  const ageRangeOptions = useMemo(
+    () => AGE_RANGES.map((v) => ({ value: v, label: text.userAgeRangeLabels[v] })),
+    [text],
+  );
+
+  const subscriptionTierOptions = useMemo(
+    () => SUBSCRIPTION_TIERS.map((v) => ({ value: v, label: text.userSubscriptionTierLabels[v] })),
+    [text],
+  );
+
+  const isPaid = value.subscriptionTier === "paid";
+
+  const handleField = <K extends keyof CreateUserFormValues>(
+    key: K,
+    next: CreateUserFormValues[K],
+  ) => {
+    onChange({ ...value, [key]: next });
+  };
+
+  const handleSubscriptionTierChange = (next: SubscriptionTier) => {
+    onChange({
+      ...value,
+      subscriptionTier: next,
+      subscriptionExpiresAt: next === "free" ? null : value.subscriptionExpiresAt,
+    });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-8">
+      <h1 className="text-xl font-bold">{text.userCreateTitle}</h1>
+
+      {createdUser && (
+        <p className="rounded-lg bg-green-50 px-4 py-3 text-sm text-green-700">
+          {text.userCreateSuccess}
+        </p>
+      )}
+
+      {error != null && <ErrorPanel message={text.userCreateError} />}
+
+      <TextField
+        label={text.userFirstName}
+        value={value.firstName}
+        onChange={(e) => handleField("firstName", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userLastName}
+        value={value.lastName}
+        onChange={(e) => handleField("lastName", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userEmail}
+        type="email"
+        value={value.email}
+        onChange={(e) => handleField("email", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userPassword}
+        type="password"
+        value={value.password}
+        onChange={(e) => handleField("password", e.target.value)}
+        required
+      />
+      <Select<AgeRange>
+        id="user-age-range"
+        label={text.userAgeRange}
+        value={value.ageRange}
+        onChange={(next) => handleField("ageRange", next)}
+        options={ageRangeOptions}
+      />
+      <Select<SubscriptionTier>
+        id="user-subscription-tier"
+        label={text.userSubscriptionTier}
+        value={value.subscriptionTier}
+        onChange={handleSubscriptionTierChange}
+        options={subscriptionTierOptions}
+      />
+      {isPaid && (
+        <TextField
+          label={text.userSubscriptionExpiresAt}
+          type="date"
+          value={value.subscriptionExpiresAt ?? ""}
+          onChange={(e) => handleField("subscriptionExpiresAt", e.target.value || null)}
+          slotProps={{ inputLabel: { shrink: true } }}
+          required
+        />
+      )}
+
+      <Button type="submit" variant="primary" isLoading={isLoading}>
+        {text.userCreateSubmit}
+      </Button>
+    </form>
+  );
+}

--- a/client/src/app/features/user/components/UserCreateForm.tsx
+++ b/client/src/app/features/user/components/UserCreateForm.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from "react";
 import type { FormEvent } from "react";
 import TextField from "@shared/uis/TextField.tsx";
-import Select from "@shared/uis/Select.tsx";
 import { Button } from "@shared/uis/Button.tsx";
 import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
-import { AGE_RANGES, SUBSCRIPTION_TIERS } from "../types";
-import type { AgeRange, CreateUserFormValues, SubscriptionTier } from "../types";
+import type { CreateUserFormValues } from "../types";
 import type { ApiUserDto } from "../apis/user-api";
 
 type Props = {
@@ -28,31 +25,11 @@ export function UserCreateForm({
 }: Props) {
   const text = useText();
 
-  const ageRangeOptions = useMemo(
-    () => AGE_RANGES.map((v) => ({ value: v, label: text.userAgeRangeLabels[v] })),
-    [text],
-  );
-
-  const subscriptionTierOptions = useMemo(
-    () => SUBSCRIPTION_TIERS.map((v) => ({ value: v, label: text.userSubscriptionTierLabels[v] })),
-    [text],
-  );
-
-  const isPaid = value.subscriptionTier === "paid";
-
   const handleField = <K extends keyof CreateUserFormValues>(
     key: K,
     next: CreateUserFormValues[K],
   ) => {
     onChange({ ...value, [key]: next });
-  };
-
-  const handleSubscriptionTierChange = (next: SubscriptionTier) => {
-    onChange({
-      ...value,
-      subscriptionTier: next,
-      subscriptionExpiresAt: next === "free" ? null : value.subscriptionExpiresAt,
-    });
   };
 
   const handleSubmit = (e: FormEvent) => {
@@ -98,30 +75,6 @@ export function UserCreateForm({
         onChange={(e) => handleField("password", e.target.value)}
         required
       />
-      <Select<AgeRange>
-        id="user-age-range"
-        label={text.userAgeRange}
-        value={value.ageRange}
-        onChange={(next) => handleField("ageRange", next)}
-        options={ageRangeOptions}
-      />
-      <Select<SubscriptionTier>
-        id="user-subscription-tier"
-        label={text.userSubscriptionTier}
-        value={value.subscriptionTier}
-        onChange={handleSubscriptionTierChange}
-        options={subscriptionTierOptions}
-      />
-      {isPaid && (
-        <TextField
-          label={text.userSubscriptionExpiresAt}
-          type="date"
-          value={value.subscriptionExpiresAt ?? ""}
-          onChange={(e) => handleField("subscriptionExpiresAt", e.target.value || null)}
-          slotProps={{ inputLabel: { shrink: true } }}
-          required
-        />
-      )}
 
       <Button type="submit" variant="primary" isLoading={isLoading}>
         {text.userCreateSubmit}

--- a/client/src/app/features/user/components/__tests__/UserCreateForm.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserCreateForm.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { UserCreateForm } from "../UserCreateForm";
+import type { CreateUserFormValues } from "../../types";
+import type { ApiUserDto } from "../../apis/user-api";
+
+const renderForm = (props: Partial<React.ComponentProps<typeof UserCreateForm>> = {}) => {
+  const value: CreateUserFormValues = {
+    firstName: "",
+    lastName: "",
+    email: "",
+    password: "",
+  };
+
+  const defaultProps: React.ComponentProps<typeof UserCreateForm> = {
+    value,
+    onChange: jest.fn(),
+    onSubmit: jest.fn(),
+    isLoading: false,
+    error: null,
+    createdUser: null,
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <UserCreateForm {...defaultProps} />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe("UserCreateForm", () => {
+  it("renders only first name, last name, email, and password fields", () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Last Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+
+    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/subscription/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onChange with the updated field when typing", () => {
+    const onChange = jest.fn();
+    renderForm({ onChange });
+
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Taro" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "Taro", lastName: "", email: "", password: "" }),
+    );
+  });
+
+  it("calls onSubmit when the form is submitted", () => {
+    const onSubmit = jest.fn();
+    const value: CreateUserFormValues = {
+      firstName: "Taro",
+      lastName: "Yamada",
+      email: "taro@example.com",
+      password: "password123",
+    };
+    renderForm({ onSubmit, value });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a success message when createdUser is present", () => {
+    const createdUser: ApiUserDto = {
+      id: 1,
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      age_range: "teens",
+      subscription_tier: "free",
+      subscription_expires_at: null,
+    };
+    renderForm({ createdUser });
+
+    expect(screen.getByText("User created successfully.")).toBeInTheDocument();
+  });
+
+  it("shows an error panel when error is present", () => {
+    renderForm({ error: new Error("boom") });
+
+    expect(screen.getByText("Failed to create user.")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/features/user/hooks/__tests__/use-create-user.test.ts
+++ b/client/src/app/features/user/hooks/__tests__/use-create-user.test.ts
@@ -1,0 +1,207 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+jest.mock("../../apis", () => ({
+  createUser: jest.fn(),
+}));
+
+jest.mock("../../mapper/to-create-user-request", () => ({
+  toCreateUserRequest: jest.fn(),
+}));
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { useCreateUser } from "../use-create-user";
+import { createUser } from "../../apis";
+import { toCreateUserRequest } from "../../mapper/to-create-user-request";
+import type { ApiUserDto, CreateUserRequest } from "../../apis/user-api";
+import type { CreateUserFormValues } from "../../types";
+
+type CreateFn = (
+  request: CreateUserRequest,
+  opts?: { signal?: AbortSignal },
+) => Promise<ApiUserDto>;
+const createUserMock = createUser as unknown as jest.MockedFunction<CreateFn>;
+
+type MapFn = (values: CreateUserFormValues) => CreateUserRequest;
+const toCreateUserRequestMock = toCreateUserRequest as unknown as jest.MockedFunction<MapFn>;
+
+const formValues: CreateUserFormValues = {
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+};
+
+const request: CreateUserRequest = {
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+};
+
+const user: ApiUserDto = {
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useCreateUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toCreateUserRequestMock.mockReturnValue(request);
+  });
+
+  test("初期状態: data=null, isLoading=false, error=null", () => {
+    const { result } = renderHook(() => useCreateUser());
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("成功パス: submit -> loading true -> data 反映 -> loading false", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      d.resolve(user);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual(user);
+    expect(result.current.error).toBeNull();
+    expect(toCreateUserRequestMock).toHaveBeenCalledWith(formValues);
+    expect(createUserMock).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ signal: expect.any(Object) }),
+    );
+  });
+
+  test("通常エラー: error に反映され、data は null のまま", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    const boom = new Error("boom");
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      d.reject(boom);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe(boom);
+  });
+
+  test("AbortError は無視される（エラー状態にしない）", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      d.reject(new DOMException("Aborted", "AbortError"));
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  test("再送信時に前のリクエストを abort する", async () => {
+    const first = deferred<ApiUserDto>();
+    const second = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    createUserMock.mockImplementation((_req, opts) => {
+      signals.push(opts?.signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    const { result } = renderHook(() => useCreateUser());
+
+    act(() => {
+      void result.current.submit(formValues);
+    });
+
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    let secondSubmit!: Promise<void>;
+    act(() => {
+      secondSubmit = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      second.resolve(user);
+      await secondSubmit;
+    });
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(result.current.data).toEqual(user);
+  });
+
+  test("アンマウント時に現在のリクエストを abort する", () => {
+    const d = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    createUserMock.mockImplementation((_req, opts) => {
+      signals.push(opts?.signal);
+      return d.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useCreateUser());
+
+    act(() => {
+      void result.current.submit(formValues);
+    });
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/client/src/app/features/user/mapper/__tests__/to-create-user-request.test.ts
+++ b/client/src/app/features/user/mapper/__tests__/to-create-user-request.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "@jest/globals";
+import { toCreateUserRequest } from "../to-create-user-request";
+import type { CreateUserFormValues } from "../../types";
+
+const makeFormValues = (overrides: Partial<CreateUserFormValues> = {}): CreateUserFormValues => ({
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+  ...overrides,
+});
+
+describe("toCreateUserRequest", () => {
+  it("maps camelCase form values to snake_case request fields", () => {
+    const request = toCreateUserRequest(makeFormValues());
+
+    expect(request).toEqual({
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      password: "password123",
+    });
+  });
+
+  it("trims firstName, lastName, and email", () => {
+    const request = toCreateUserRequest(
+      makeFormValues({
+        firstName: "  Taro  ",
+        lastName: "  Yamada  ",
+        email: "  taro@example.com  ",
+      }),
+    );
+
+    expect(request.first_name).toBe("Taro");
+    expect(request.last_name).toBe("Yamada");
+    expect(request.email).toBe("taro@example.com");
+  });
+
+  it("does not trim password", () => {
+    const request = toCreateUserRequest(makeFormValues({ password: "  spaced out  " }));
+
+    expect(request.password).toBe("  spaced out  ");
+  });
+});

--- a/client/src/app/features/user/mapper/to-create-user-request.ts
+++ b/client/src/app/features/user/mapper/to-create-user-request.ts
@@ -6,7 +6,4 @@ export const toCreateUserRequest = (values: CreateUserFormValues): CreateUserReq
   last_name: values.lastName.trim(),
   email: values.email.trim(),
   password: values.password,
-  age_range: values.ageRange,
-  subscription_tier: values.subscriptionTier,
-  subscription_expires_at: values.subscriptionTier === "paid" ? values.subscriptionExpiresAt : null,
 });

--- a/client/src/app/features/user/types.ts
+++ b/client/src/app/features/user/types.ts
@@ -9,7 +9,4 @@ export type CreateUserFormValues = {
   lastName: string;
   email: string;
   password: string;
-  ageRange: AgeRange;
-  subscriptionTier: SubscriptionTier;
-  subscriptionExpiresAt: string | null;
 };

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -69,21 +69,6 @@
   "userLastName": "Last Name",
   "userEmail": "Email",
   "userPassword": "Password",
-  "userAgeRange": "Age Range",
-  "userAgeRangeLabels": {
-    "teens": "Teens",
-    "20s": "20s",
-    "30s": "30s",
-    "40s": "40s",
-    "50s": "50s",
-    "60plus": "60+"
-  },
-  "userSubscriptionTier": "Subscription",
-  "userSubscriptionTierLabels": {
-    "free": "Free",
-    "paid": "Paid"
-  },
-  "userSubscriptionExpiresAt": "Subscription Expires At",
   "userCreateSubmit": "Create",
   "userCreateSuccess": "User created successfully.",
   "userCreateError": "Failed to create user."

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -63,5 +63,28 @@
   "viewAllResults": "View all results",
   "unescoCriteriaSource": "UNESCO official criteria page",
   "worldHeritageBasics": "World Heritage Basics",
-  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means."
+  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means.",
+  "userCreateTitle": "Create User",
+  "userFirstName": "First Name",
+  "userLastName": "Last Name",
+  "userEmail": "Email",
+  "userPassword": "Password",
+  "userAgeRange": "Age Range",
+  "userAgeRangeLabels": {
+    "teens": "Teens",
+    "20s": "20s",
+    "30s": "30s",
+    "40s": "40s",
+    "50s": "50s",
+    "60plus": "60+"
+  },
+  "userSubscriptionTier": "Subscription",
+  "userSubscriptionTierLabels": {
+    "free": "Free",
+    "paid": "Paid"
+  },
+  "userSubscriptionExpiresAt": "Subscription Expires At",
+  "userCreateSubmit": "Create",
+  "userCreateSuccess": "User created successfully.",
+  "userCreateError": "Failed to create user."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -63,5 +63,28 @@
   "viewAllResults": "すべての結果を見る",
   "unescoCriteriaSource": "UNESCO 公式の登録基準ページ",
   "worldHeritageBasics": "世界遺産の基礎知識",
-  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。"
+  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。",
+  "userCreateTitle": "ユーザー作成",
+  "userFirstName": "名",
+  "userLastName": "姓",
+  "userEmail": "メールアドレス",
+  "userPassword": "パスワード",
+  "userAgeRange": "年齢層",
+  "userAgeRangeLabels": {
+    "teens": "10代",
+    "20s": "20代",
+    "30s": "30代",
+    "40s": "40代",
+    "50s": "50代",
+    "60plus": "60代以上"
+  },
+  "userSubscriptionTier": "サブスクリプション",
+  "userSubscriptionTierLabels": {
+    "free": "無料",
+    "paid": "有料"
+  },
+  "userSubscriptionExpiresAt": "サブスクリプション有効期限",
+  "userCreateSubmit": "作成",
+  "userCreateSuccess": "ユーザーを作成しました。",
+  "userCreateError": "ユーザーの作成に失敗しました。"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -69,21 +69,6 @@
   "userLastName": "姓",
   "userEmail": "メールアドレス",
   "userPassword": "パスワード",
-  "userAgeRange": "年齢層",
-  "userAgeRangeLabels": {
-    "teens": "10代",
-    "20s": "20代",
-    "30s": "30代",
-    "40s": "40代",
-    "50s": "50代",
-    "60plus": "60代以上"
-  },
-  "userSubscriptionTier": "サブスクリプション",
-  "userSubscriptionTierLabels": {
-    "free": "無料",
-    "paid": "有料"
-  },
-  "userSubscriptionExpiresAt": "サブスクリプション有効期限",
   "userCreateSubmit": "作成",
   "userCreateSuccess": "ユーザーを作成しました。",
   "userCreateError": "ユーザーの作成に失敗しました。"


### PR DESCRIPTION
## Summary
- Add `UserCreateForm` presentational component (fields, validation, success/error states)
- Add en/ja i18n text keys for the create-user form
- Drop age range and subscription plan from the registration flow entirely — registration now only collects first/last name, email, and password. Age range and subscription plan move to the User update flow (#416).

Part of the `feat/user-ui-create` stack (4/5): type → mapper → hooks → ui-components → container.
Stacked on #407 — merge that first.

## Why a new PR instead of reusing #409
#409 originally bundled the component + `AppRoutes.tsx` routing + i18n, and was stacked *under* `feat/user-ui-create-container`. That created a circular dependency: `user-create-container.tsx` imports `UserCreateForm`, but the container branch didn't have that file yet, which broke `npm run build` on PR #408 (see CI failure).

Fixed by re-splitting so the presentational component (no dependency on the container) ships before the container, and route wiring (which depends on the container) ships after. #409 is already merged and can't be retargeted, so this PR replaces it with the corrected, narrower scope.

## Why age range / subscription were dropped
UX review of the registration screen found the plan/age fields buried mid-form with no explanation of why registration is needed or what a paid plan offers. Splitting registration (name/email/password only) from plan selection (a later step via the update flow) keeps the form focused and matches the existing Create/Update feature split.

## Test plan
- [x] `npm run typecheck` (verified locally, passes)