### PR TITLE
feat(auth): add login domain types

### DIFF
--- a/client/src/app/features/auth/types.ts
+++ b/client/src/app/features/auth/types.ts
@@ -1,0 +1,4 @@
+export type LoginFormValues = {
+  email: string;
+  password: string;
+};


### PR DESCRIPTION
## Summary
- Add `LoginFormValues` domain type for the login form (email, password)

Part of the `feat/user-login` stack (1/5): type → mapper → hooks → container → ui-components.

## Test plan
- [x] `npx tsc --noEmit` (verified locally, passes)