### PR TITLE
feat(user): implement user creation UI (type / mapper / hooks / container / UI components)

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { createUserApi } from "./user-api";
+import type { ApiCreateUserResponse, ApiUserDto, CreateUserRequest } from "./user-api";
+
+type MockResponse = Pick<Response, "ok" | "status" | "json">;
+
+let fetchSpy: jest.MockedFunction<typeof fetch>;
+
+const API_BASE = "http://localhost:8700";
+const ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/users`;
+
+const makeOkResponse = (body: ApiCreateUserResponse): MockResponse => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+const makeNgResponse = (status: number): MockResponse => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+});
+
+const makeRequest = (overrides: Partial<CreateUserRequest> = {}): CreateUserRequest => ({
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+  ...overrides,
+});
+
+const makeUserDto = (overrides: Partial<ApiUserDto> = {}): ApiUserDto => ({
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+  ...overrides,
+});
+
+describe("createUserApi", () => {
+  let api: ReturnType<typeof createUserApi>;
+
+  beforeEach(() => {
+    fetchSpy = jest.fn() as jest.MockedFunction<typeof fetch>;
+    api = createUserApi({ apiBase: API_BASE, fetchImpl: fetchSpy });
+  });
+
+  describe("createUser", () => {
+    it("posts the request body to the users endpoint", async () => {
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const request = makeRequest();
+      const out = await api.createUser(request);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(request),
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          }),
+          credentials: "omit",
+        }),
+      );
+      expect(out).toEqual(user);
+    });
+
+    it("trims trailing slash from apiBase", async () => {
+      const apiWithTrailingSlash = createUserApi({
+        apiBase: "http://localhost:8700/",
+        fetchImpl: fetchSpy,
+      });
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      await apiWithTrailingSlash.createUser(makeRequest());
+
+      expect(fetchSpy).toHaveBeenCalledWith(ENDPOINT, expect.objectContaining({ method: "POST" }));
+    });
+
+    it("merges headers and allows credentials and signal override", async () => {
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const ac = new AbortController();
+      await api.createUser(makeRequest(), {
+        headers: { "X-Trace": "t" },
+        credentials: "include",
+        signal: ac.signal,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "X-Trace": "t",
+          }),
+          credentials: "include",
+          signal: ac.signal,
+        }),
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(api.createUser(makeRequest())).rejects.toThrow("HTTP 422");
+    });
+
+    it("throws when API status is not success", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "error", data: { message: "invalid" } }) as Response,
+      );
+
+      await expect(api.createUser(makeRequest())).rejects.toThrow(
+        "API status is not success: error",
+      );
+    });
+  });
+
+  it("throws when apiBase is empty", () => {
+    expect(() => createUserApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
+      "apiBase is required",
+    );
+  });
+});

--- a/client/src/app/features/user/apis/index.ts
+++ b/client/src/app/features/user/apis/index.ts
@@ -1,0 +1,11 @@
+import { createUserApi } from "./user-api.ts";
+
+const apiBase = import.meta.env.VITE_API_BASE_URL;
+
+if (!apiBase) {
+  throw new Error("VITE_API_BASE_URL is not set");
+}
+
+const userApi = createUserApi({ apiBase });
+
+export const createUser = userApi.createUser;

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -10,9 +10,6 @@ export type CreateUserRequest = {
   last_name: string;
   email: string;
   password: string;
-  age_range: AgeRange;
-  subscription_tier: SubscriptionTier;
-  subscription_expires_at: string | null;
 };
 
 export type ApiUserDto = {

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -1,0 +1,73 @@
+import type { AgeRange, SubscriptionTier } from "../types";
+
+export type UserApiDeps = {
+  apiBase: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type CreateUserRequest = {
+  first_name: string;
+  last_name: string;
+  email: string;
+  password: string;
+  age_range: AgeRange;
+  subscription_tier: SubscriptionTier;
+  subscription_expires_at: string | null;
+};
+
+export type ApiUserDto = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  age_range: AgeRange;
+  subscription_tier: SubscriptionTier;
+  subscription_expires_at: string | null;
+};
+
+export type ApiCreateUserResponse =
+  | { status: "success"; data: ApiUserDto }
+  | { status: "error"; data: unknown };
+
+const normalizeApiBase = (apiBase: string): string => apiBase.replace(/\/+$/, "");
+
+export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
+  if (!apiBase) {
+    throw new Error("apiBase is required");
+  }
+
+  const base = normalizeApiBase(apiBase);
+  const endpoint = `${base}/api/v1/users`;
+
+  const withCommonInit = (init?: RequestInit): RequestInit => ({
+    ...init,
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: init?.credentials ?? "omit",
+    signal: init?.signal,
+  });
+
+  return {
+    async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
+      const response = await fetchImpl(endpoint, {
+        ...withCommonInit(init),
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = (await response.json()) as ApiCreateUserResponse;
+      if (json.status !== "success") {
+        throw new Error(`API status is not success: ${json.status}`);
+      }
+
+      return json.data;
+    },
+  };
+};

--- a/client/src/app/features/user/components/UserCreateForm.tsx
+++ b/client/src/app/features/user/components/UserCreateForm.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+import type { FormEvent } from "react";
+import TextField from "@shared/uis/TextField.tsx";
+import Select from "@shared/uis/Select.tsx";
+import { Button } from "@shared/uis/Button.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import { AGE_RANGES, SUBSCRIPTION_TIERS } from "../types";
+import type { AgeRange, CreateUserFormValues, SubscriptionTier } from "../types";
+import type { ApiUserDto } from "../apis/user-api";
+
+type Props = {
+  value: CreateUserFormValues;
+  onChange: (next: CreateUserFormValues) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+  error: unknown;
+  createdUser: ApiUserDto | null;
+};
+
+export function UserCreateForm({
+  value,
+  onChange,
+  onSubmit,
+  isLoading,
+  error,
+  createdUser,
+}: Props) {
+  const text = useText();
+
+  const ageRangeOptions = useMemo(
+    () => AGE_RANGES.map((v) => ({ value: v, label: text.userAgeRangeLabels[v] })),
+    [text],
+  );
+
+  const subscriptionTierOptions = useMemo(
+    () => SUBSCRIPTION_TIERS.map((v) => ({ value: v, label: text.userSubscriptionTierLabels[v] })),
+    [text],
+  );
+
+  const isPaid = value.subscriptionTier === "paid";
+
+  const handleField = <K extends keyof CreateUserFormValues>(
+    key: K,
+    next: CreateUserFormValues[K],
+  ) => {
+    onChange({ ...value, [key]: next });
+  };
+
+  const handleSubscriptionTierChange = (next: SubscriptionTier) => {
+    onChange({
+      ...value,
+      subscriptionTier: next,
+      subscriptionExpiresAt: next === "free" ? null : value.subscriptionExpiresAt,
+    });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-8">
+      <h1 className="text-xl font-bold">{text.userCreateTitle}</h1>
+
+      {createdUser && (
+        <p className="rounded-lg bg-green-50 px-4 py-3 text-sm text-green-700">
+          {text.userCreateSuccess}
+        </p>
+      )}
+
+      {error != null && <ErrorPanel message={text.userCreateError} />}
+
+      <TextField
+        label={text.userFirstName}
+        value={value.firstName}
+        onChange={(e) => handleField("firstName", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userLastName}
+        value={value.lastName}
+        onChange={(e) => handleField("lastName", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userEmail}
+        type="email"
+        value={value.email}
+        onChange={(e) => handleField("email", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userPassword}
+        type="password"
+        value={value.password}
+        onChange={(e) => handleField("password", e.target.value)}
+        required
+      />
+      <Select<AgeRange>
+        id="user-age-range"
+        label={text.userAgeRange}
+        value={value.ageRange}
+        onChange={(next) => handleField("ageRange", next)}
+        options={ageRangeOptions}
+      />
+      <Select<SubscriptionTier>
+        id="user-subscription-tier"
+        label={text.userSubscriptionTier}
+        value={value.subscriptionTier}
+        onChange={handleSubscriptionTierChange}
+        options={subscriptionTierOptions}
+      />
+      {isPaid && (
+        <TextField
+          label={text.userSubscriptionExpiresAt}
+          type="date"
+          value={value.subscriptionExpiresAt ?? ""}
+          onChange={(e) => handleField("subscriptionExpiresAt", e.target.value || null)}
+          slotProps={{ inputLabel: { shrink: true } }}
+          required
+        />
+      )}
+
+      <Button type="submit" variant="primary" isLoading={isLoading}>
+        {text.userCreateSubmit}
+      </Button>
+    </form>
+  );
+}

--- a/client/src/app/features/user/components/UserCreateForm.tsx
+++ b/client/src/app/features/user/components/UserCreateForm.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from "react";
 import type { FormEvent } from "react";
 import TextField from "@shared/uis/TextField.tsx";
-import Select from "@shared/uis/Select.tsx";
 import { Button } from "@shared/uis/Button.tsx";
 import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
-import { AGE_RANGES, SUBSCRIPTION_TIERS } from "../types";
-import type { AgeRange, CreateUserFormValues, SubscriptionTier } from "../types";
+import type { CreateUserFormValues } from "../types";
 import type { ApiUserDto } from "../apis/user-api";
 
 type Props = {
@@ -28,31 +25,11 @@ export function UserCreateForm({
 }: Props) {
   const text = useText();
 
-  const ageRangeOptions = useMemo(
-    () => AGE_RANGES.map((v) => ({ value: v, label: text.userAgeRangeLabels[v] })),
-    [text],
-  );
-
-  const subscriptionTierOptions = useMemo(
-    () => SUBSCRIPTION_TIERS.map((v) => ({ value: v, label: text.userSubscriptionTierLabels[v] })),
-    [text],
-  );
-
-  const isPaid = value.subscriptionTier === "paid";
-
   const handleField = <K extends keyof CreateUserFormValues>(
     key: K,
     next: CreateUserFormValues[K],
   ) => {
     onChange({ ...value, [key]: next });
-  };
-
-  const handleSubscriptionTierChange = (next: SubscriptionTier) => {
-    onChange({
-      ...value,
-      subscriptionTier: next,
-      subscriptionExpiresAt: next === "free" ? null : value.subscriptionExpiresAt,
-    });
   };
 
   const handleSubmit = (e: FormEvent) => {
@@ -98,30 +75,6 @@ export function UserCreateForm({
         onChange={(e) => handleField("password", e.target.value)}
         required
       />
-      <Select<AgeRange>
-        id="user-age-range"
-        label={text.userAgeRange}
-        value={value.ageRange}
-        onChange={(next) => handleField("ageRange", next)}
-        options={ageRangeOptions}
-      />
-      <Select<SubscriptionTier>
-        id="user-subscription-tier"
-        label={text.userSubscriptionTier}
-        value={value.subscriptionTier}
-        onChange={handleSubscriptionTierChange}
-        options={subscriptionTierOptions}
-      />
-      {isPaid && (
-        <TextField
-          label={text.userSubscriptionExpiresAt}
-          type="date"
-          value={value.subscriptionExpiresAt ?? ""}
-          onChange={(e) => handleField("subscriptionExpiresAt", e.target.value || null)}
-          slotProps={{ inputLabel: { shrink: true } }}
-          required
-        />
-      )}
 
       <Button type="submit" variant="primary" isLoading={isLoading}>
         {text.userCreateSubmit}

--- a/client/src/app/features/user/components/__tests__/UserCreateForm.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserCreateForm.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { UserCreateForm } from "../UserCreateForm";
+import type { CreateUserFormValues } from "../../types";
+import type { ApiUserDto } from "../../apis/user-api";
+
+const renderForm = (props: Partial<React.ComponentProps<typeof UserCreateForm>> = {}) => {
+  const value: CreateUserFormValues = {
+    firstName: "",
+    lastName: "",
+    email: "",
+    password: "",
+  };
+
+  const defaultProps: React.ComponentProps<typeof UserCreateForm> = {
+    value,
+    onChange: jest.fn(),
+    onSubmit: jest.fn(),
+    isLoading: false,
+    error: null,
+    createdUser: null,
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <UserCreateForm {...defaultProps} />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe("UserCreateForm", () => {
+  it("renders only first name, last name, email, and password fields", () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Last Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+
+    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/subscription/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onChange with the updated field when typing", () => {
+    const onChange = jest.fn();
+    renderForm({ onChange });
+
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Taro" } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "Taro", lastName: "", email: "", password: "" }),
+    );
+  });
+
+  it("calls onSubmit when the form is submitted", () => {
+    const onSubmit = jest.fn();
+    const value: CreateUserFormValues = {
+      firstName: "Taro",
+      lastName: "Yamada",
+      email: "taro@example.com",
+      password: "password123",
+    };
+    renderForm({ onSubmit, value });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a success message when createdUser is present", () => {
+    const createdUser: ApiUserDto = {
+      id: 1,
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      age_range: "teens",
+      subscription_tier: "free",
+      subscription_expires_at: null,
+    };
+    renderForm({ createdUser });
+
+    expect(screen.getByText("User created successfully.")).toBeInTheDocument();
+  });
+
+  it("shows an error panel when error is present", () => {
+    renderForm({ error: new Error("boom") });
+
+    expect(screen.getByText("Failed to create user.")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/features/user/containers/__tests__/user-create-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-create-container.test.tsx
@@ -1,0 +1,105 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { CreateUserFormValues } from "../../types";
+import type { ApiUserDto } from "../../apis/user-api";
+
+const submitMock = jest.fn();
+const useCreateUserMock = jest.fn();
+
+jest.mock("../../hooks/use-create-user", () => ({
+  useCreateUser: () => useCreateUserMock(),
+}));
+
+jest.mock("../../components/UserCreateForm", () => ({
+  __esModule: true,
+  UserCreateForm: function MockUserCreateForm(props: {
+    value: CreateUserFormValues;
+    onChange: (next: CreateUserFormValues) => void;
+    onSubmit: () => void;
+    isLoading: boolean;
+    error: unknown;
+    createdUser: ApiUserDto | null;
+  }) {
+    return (
+      <div>
+        <span data-testid="first-name">{props.value.firstName}</span>
+        <span data-testid="is-loading">{String(props.isLoading)}</span>
+        <span data-testid="error">{props.error ? "has-error" : "no-error"}</span>
+        <span data-testid="created-user">{props.createdUser ? props.createdUser.email : ""}</span>
+        <button type="button" onClick={() => props.onChange({ ...props.value, firstName: "Taro" })}>
+          change
+        </button>
+        <button type="button" onClick={props.onSubmit}>
+          submit
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { UserCreateContainer } from "../user-create-container";
+
+describe("UserCreateContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCreateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("renders the form with the default draft values", () => {
+    render(<UserCreateContainer />);
+
+    expect(screen.getByTestId("first-name").textContent).toBe("");
+    expect(screen.getByTestId("is-loading").textContent).toBe("false");
+    expect(screen.getByTestId("error").textContent).toBe("no-error");
+  });
+
+  it("updates the draft when the form calls onChange", () => {
+    render(<UserCreateContainer />);
+
+    fireEvent.click(screen.getByRole("button", { name: "change" }));
+
+    expect(screen.getByTestId("first-name").textContent).toBe("Taro");
+  });
+
+  it("calls submit with the current draft when the form calls onSubmit", () => {
+    render(<UserCreateContainer />);
+
+    fireEvent.click(screen.getByRole("button", { name: "change" }));
+    fireEvent.click(screen.getByRole("button", { name: "submit" }));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "Taro", lastName: "", email: "", password: "" }),
+    );
+  });
+
+  it("passes through isLoading, error, and createdUser from the hook", () => {
+    const createdUser: ApiUserDto = {
+      id: 1,
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      age_range: "teens",
+      subscription_tier: "free",
+      subscription_expires_at: null,
+    };
+    useCreateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: createdUser,
+      isLoading: true,
+      error: new Error("boom"),
+    });
+
+    render(<UserCreateContainer />);
+
+    expect(screen.getByTestId("is-loading").textContent).toBe("true");
+    expect(screen.getByTestId("error").textContent).toBe("has-error");
+    expect(screen.getByTestId("created-user").textContent).toBe("taro@example.com");
+  });
+});

--- a/client/src/app/features/user/containers/user-create-container.tsx
+++ b/client/src/app/features/user/containers/user-create-container.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+import { useCreateUser } from "../hooks/use-create-user";
+import { DEFAULT_CREATE_USER_FORM_VALUES } from "../mapper/user.types";
+import type { CreateUserFormValues } from "../types";
+import { UserCreateForm } from "../components/UserCreateForm";
+
+export function UserCreateContainer() {
+  const [draft, setDraft] = useState<CreateUserFormValues>(DEFAULT_CREATE_USER_FORM_VALUES);
+  const { submit, data, isLoading, error } = useCreateUser();
+
+  const handleChange = useCallback((next: CreateUserFormValues) => {
+    setDraft(next);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    void submit(draft);
+  }, [draft, submit]);
+
+  return (
+    <UserCreateForm
+      value={draft}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      error={error}
+      createdUser={data}
+    />
+  );
+}

--- a/client/src/app/features/user/hooks/__tests__/use-create-user.test.ts
+++ b/client/src/app/features/user/hooks/__tests__/use-create-user.test.ts
@@ -1,0 +1,207 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+jest.mock("../../apis", () => ({
+  createUser: jest.fn(),
+}));
+
+jest.mock("../../mapper/to-create-user-request", () => ({
+  toCreateUserRequest: jest.fn(),
+}));
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { useCreateUser } from "../use-create-user";
+import { createUser } from "../../apis";
+import { toCreateUserRequest } from "../../mapper/to-create-user-request";
+import type { ApiUserDto, CreateUserRequest } from "../../apis/user-api";
+import type { CreateUserFormValues } from "../../types";
+
+type CreateFn = (
+  request: CreateUserRequest,
+  opts?: { signal?: AbortSignal },
+) => Promise<ApiUserDto>;
+const createUserMock = createUser as unknown as jest.MockedFunction<CreateFn>;
+
+type MapFn = (values: CreateUserFormValues) => CreateUserRequest;
+const toCreateUserRequestMock = toCreateUserRequest as unknown as jest.MockedFunction<MapFn>;
+
+const formValues: CreateUserFormValues = {
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+};
+
+const request: CreateUserRequest = {
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+};
+
+const user: ApiUserDto = {
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useCreateUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toCreateUserRequestMock.mockReturnValue(request);
+  });
+
+  test("初期状態: data=null, isLoading=false, error=null", () => {
+    const { result } = renderHook(() => useCreateUser());
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("成功パス: submit -> loading true -> data 反映 -> loading false", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      d.resolve(user);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual(user);
+    expect(result.current.error).toBeNull();
+    expect(toCreateUserRequestMock).toHaveBeenCalledWith(formValues);
+    expect(createUserMock).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ signal: expect.any(Object) }),
+    );
+  });
+
+  test("通常エラー: error に反映され、data は null のまま", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    const boom = new Error("boom");
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      d.reject(boom);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe(boom);
+  });
+
+  test("AbortError は無視される（エラー状態にしない）", async () => {
+    const d = deferred<ApiUserDto>();
+    createUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useCreateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      d.reject(new DOMException("Aborted", "AbortError"));
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  test("再送信時に前のリクエストを abort する", async () => {
+    const first = deferred<ApiUserDto>();
+    const second = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    createUserMock.mockImplementation((_req, opts) => {
+      signals.push(opts?.signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    const { result } = renderHook(() => useCreateUser());
+
+    act(() => {
+      void result.current.submit(formValues);
+    });
+
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    let secondSubmit!: Promise<void>;
+    act(() => {
+      secondSubmit = result.current.submit(formValues);
+    });
+
+    await act(async () => {
+      second.resolve(user);
+      await secondSubmit;
+    });
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(result.current.data).toEqual(user);
+  });
+
+  test("アンマウント時に現在のリクエストを abort する", () => {
+    const d = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    createUserMock.mockImplementation((_req, opts) => {
+      signals.push(opts?.signal);
+      return d.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useCreateUser());
+
+    act(() => {
+      void result.current.submit(formValues);
+    });
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/client/src/app/features/user/hooks/use-create-user.ts
+++ b/client/src/app/features/user/hooks/use-create-user.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createUser } from "../apis";
+import { toCreateUserRequest } from "../mapper/to-create-user-request";
+import type { ApiUserDto } from "../apis/user-api";
+import type { CreateUserFormValues } from "../types";
+
+const isAbortError = (e: unknown): boolean => {
+  return e instanceof DOMException && e.name === "AbortError";
+};
+
+export function useCreateUser() {
+  const [data, setData] = useState<ApiUserDto | null>(null);
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const submit = useCallback(async (values: CreateUserFormValues) => {
+    abortRef.current?.abort();
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const created = await createUser(toCreateUserRequest(values), {
+        signal: abortController.signal,
+      });
+      setData(created);
+    } catch (e) {
+      if (!isAbortError(e)) setError(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { submit, data, isLoading, error };
+}

--- a/client/src/app/features/user/mapper/__tests__/to-create-user-request.test.ts
+++ b/client/src/app/features/user/mapper/__tests__/to-create-user-request.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "@jest/globals";
+import { toCreateUserRequest } from "../to-create-user-request";
+import type { CreateUserFormValues } from "../../types";
+
+const makeFormValues = (overrides: Partial<CreateUserFormValues> = {}): CreateUserFormValues => ({
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  password: "password123",
+  ...overrides,
+});
+
+describe("toCreateUserRequest", () => {
+  it("maps camelCase form values to snake_case request fields", () => {
+    const request = toCreateUserRequest(makeFormValues());
+
+    expect(request).toEqual({
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+      password: "password123",
+    });
+  });
+
+  it("trims firstName, lastName, and email", () => {
+    const request = toCreateUserRequest(
+      makeFormValues({
+        firstName: "  Taro  ",
+        lastName: "  Yamada  ",
+        email: "  taro@example.com  ",
+      }),
+    );
+
+    expect(request.first_name).toBe("Taro");
+    expect(request.last_name).toBe("Yamada");
+    expect(request.email).toBe("taro@example.com");
+  });
+
+  it("does not trim password", () => {
+    const request = toCreateUserRequest(makeFormValues({ password: "  spaced out  " }));
+
+    expect(request.password).toBe("  spaced out  ");
+  });
+});

--- a/client/src/app/features/user/mapper/to-create-user-request.ts
+++ b/client/src/app/features/user/mapper/to-create-user-request.ts
@@ -1,0 +1,12 @@
+import type { CreateUserFormValues } from "../types";
+import type { CreateUserRequest } from "../apis/user-api";
+
+export const toCreateUserRequest = (values: CreateUserFormValues): CreateUserRequest => ({
+  first_name: values.firstName.trim(),
+  last_name: values.lastName.trim(),
+  email: values.email.trim(),
+  password: values.password,
+  age_range: values.ageRange,
+  subscription_tier: values.subscriptionTier,
+  subscription_expires_at: values.subscriptionTier === "paid" ? values.subscriptionExpiresAt : null,
+});

--- a/client/src/app/features/user/mapper/to-create-user-request.ts
+++ b/client/src/app/features/user/mapper/to-create-user-request.ts
@@ -6,7 +6,4 @@ export const toCreateUserRequest = (values: CreateUserFormValues): CreateUserReq
   last_name: values.lastName.trim(),
   email: values.email.trim(),
   password: values.password,
-  age_range: values.ageRange,
-  subscription_tier: values.subscriptionTier,
-  subscription_expires_at: values.subscriptionTier === "paid" ? values.subscriptionExpiresAt : null,
 });

--- a/client/src/app/features/user/mapper/user.types.ts
+++ b/client/src/app/features/user/mapper/user.types.ts
@@ -1,0 +1,8 @@
+import type { CreateUserFormValues } from "../types";
+
+export const DEFAULT_CREATE_USER_FORM_VALUES: CreateUserFormValues = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+};

--- a/client/src/app/features/user/types.ts
+++ b/client/src/app/features/user/types.ts
@@ -9,7 +9,4 @@ export type CreateUserFormValues = {
   lastName: string;
   email: string;
   password: string;
-  ageRange: AgeRange;
-  subscriptionTier: SubscriptionTier;
-  subscriptionExpiresAt: string | null;
 };

--- a/client/src/app/features/user/types.ts
+++ b/client/src/app/features/user/types.ts
@@ -1,0 +1,15 @@
+export const AGE_RANGES = ["teens", "20s", "30s", "40s", "50s", "60plus"] as const;
+export type AgeRange = (typeof AGE_RANGES)[number];
+
+export const SUBSCRIPTION_TIERS = ["free", "paid"] as const;
+export type SubscriptionTier = (typeof SUBSCRIPTION_TIERS)[number];
+
+export type CreateUserFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  ageRange: AgeRange;
+  subscriptionTier: SubscriptionTier;
+  subscriptionExpiresAt: string | null;
+};

--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { WorldHeritageDetailContainer } from "@features/top/containers/world-her
 import { CriteriaDetailContainer } from "@features/top/containers/criteria-detail-container.tsx";
 import { HeritageGalleryContainer } from "@features/top/containers/heritage-gallery-container.tsx";
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
+import { UserCreateContainer } from "@features/user/containers/user-create-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { AppLayout } from "@shared/layout/AppLayout.tsx";
@@ -19,6 +20,7 @@ export function AppRoutes() {
             <Route path="/heritages/criteria/:code" element={<CriteriaDetailContainer />} />
             <Route path="/heritages/:id/gallery" element={<HeritageGalleryContainer />} />
             <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
+            <Route path="/users/new" element={<UserCreateContainer />} />
             <Route path="*" element={<Navigate to="/heritages" replace />} />
           </Routes>
         </AppLayout>

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -69,21 +69,6 @@
   "userLastName": "Last Name",
   "userEmail": "Email",
   "userPassword": "Password",
-  "userAgeRange": "Age Range",
-  "userAgeRangeLabels": {
-    "teens": "Teens",
-    "20s": "20s",
-    "30s": "30s",
-    "40s": "40s",
-    "50s": "50s",
-    "60plus": "60+"
-  },
-  "userSubscriptionTier": "Subscription",
-  "userSubscriptionTierLabels": {
-    "free": "Free",
-    "paid": "Paid"
-  },
-  "userSubscriptionExpiresAt": "Subscription Expires At",
   "userCreateSubmit": "Create",
   "userCreateSuccess": "User created successfully.",
   "userCreateError": "Failed to create user."

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -63,5 +63,28 @@
   "viewAllResults": "View all results",
   "unescoCriteriaSource": "UNESCO official criteria page",
   "worldHeritageBasics": "World Heritage Basics",
-  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means."
+  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means.",
+  "userCreateTitle": "Create User",
+  "userFirstName": "First Name",
+  "userLastName": "Last Name",
+  "userEmail": "Email",
+  "userPassword": "Password",
+  "userAgeRange": "Age Range",
+  "userAgeRangeLabels": {
+    "teens": "Teens",
+    "20s": "20s",
+    "30s": "30s",
+    "40s": "40s",
+    "50s": "50s",
+    "60plus": "60+"
+  },
+  "userSubscriptionTier": "Subscription",
+  "userSubscriptionTierLabels": {
+    "free": "Free",
+    "paid": "Paid"
+  },
+  "userSubscriptionExpiresAt": "Subscription Expires At",
+  "userCreateSubmit": "Create",
+  "userCreateSuccess": "User created successfully.",
+  "userCreateError": "Failed to create user."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -63,5 +63,28 @@
   "viewAllResults": "すべての結果を見る",
   "unescoCriteriaSource": "UNESCO 公式の登録基準ページ",
   "worldHeritageBasics": "世界遺産の基礎知識",
-  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。"
+  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。",
+  "userCreateTitle": "ユーザー作成",
+  "userFirstName": "名",
+  "userLastName": "姓",
+  "userEmail": "メールアドレス",
+  "userPassword": "パスワード",
+  "userAgeRange": "年齢層",
+  "userAgeRangeLabels": {
+    "teens": "10代",
+    "20s": "20代",
+    "30s": "30代",
+    "40s": "40代",
+    "50s": "50代",
+    "60plus": "60代以上"
+  },
+  "userSubscriptionTier": "サブスクリプション",
+  "userSubscriptionTierLabels": {
+    "free": "無料",
+    "paid": "有料"
+  },
+  "userSubscriptionExpiresAt": "サブスクリプション有効期限",
+  "userCreateSubmit": "作成",
+  "userCreateSuccess": "ユーザーを作成しました。",
+  "userCreateError": "ユーザーの作成に失敗しました。"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -69,21 +69,6 @@
   "userLastName": "姓",
   "userEmail": "メールアドレス",
   "userPassword": "パスワード",
-  "userAgeRange": "年齢層",
-  "userAgeRangeLabels": {
-    "teens": "10代",
-    "20s": "20代",
-    "30s": "30代",
-    "40s": "40代",
-    "50s": "50代",
-    "60plus": "60代以上"
-  },
-  "userSubscriptionTier": "サブスクリプション",
-  "userSubscriptionTierLabels": {
-    "free": "無料",
-    "paid": "有料"
-  },
-  "userSubscriptionExpiresAt": "サブスクリプション有効期限",
   "userCreateSubmit": "作成",
   "userCreateSuccess": "ユーザーを作成しました。",
   "userCreateError": "ユーザーの作成に失敗しました。"


### PR DESCRIPTION
## Summary
- Add the User creation feature end-to-end: domain types + API client, mapper (form values → create-user request), `useCreateUser` hook, `UserCreateContainer`, `UserCreateForm` UI component, and the `/users/new` route
- Registration collects first/last name, email, and password only

## Related
Closes #382

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` (user feature tests)