### PR TITLE
fix(user): correct create-user endpoint path

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -7,7 +7,7 @@ type MockResponse = Pick<Response, "ok" | "status" | "json">;
 let fetchSpy: jest.MockedFunction<typeof fetch>;
 
 const API_BASE = "http://localhost:8700";
-const ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/users`;
+const ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/user/create`;
 
 const makeOkResponse = (body: ApiCreateUserResponse): MockResponse => ({
   ok: true,

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -34,7 +34,7 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
   }
 
   const base = normalizeApiBase(apiBase);
-  const endpoint = `${base}/api/v1/users`;
+  const endpoint = `${base}/api/v1/user/create`;
 
   const withCommonInit = (init?: RequestInit): RequestInit => ({
     ...init,


### PR DESCRIPTION
## Summary
- `createUserApi` was posting to `/api/v1/users`, which does not exist on the backend
- The actual route (confirmed via `php artisan route:list` against the running backend) is `POST /api/v1/user/create`
- Fixes the 404 that PR #440 shipped

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/apis`
- [x] Confirmed against the running backend that the request no longer 404s