### PR TITLE
feat(auth): add login API client

### DIFF
--- a/client/src/app/features/auth/apis/auth-api.test.ts
+++ b/client/src/app/features/auth/apis/auth-api.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { createAuthApi } from "./auth-api";
+import type { ApiCurrentUserDto } from "./auth-api";
+
+type MockResponse = Pick<Response, "ok" | "status" | "json">;
+
+let fetchSpy: jest.MockedFunction<typeof fetch>;
+
+const API_BASE = "http://localhost:8700";
+const TOKEN = "1|abcdef";
+
+const makeOkResponse = (body: unknown): MockResponse => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+const makeNgResponse = (status: number): MockResponse => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+});
+
+const makeUser = (overrides: Partial<ApiCurrentUserDto> = {}): ApiCurrentUserDto => ({
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  ...overrides,
+});
+
+describe("createAuthApi", () => {
+  let api: ReturnType<typeof createAuthApi>;
+
+  beforeEach(() => {
+    fetchSpy = jest.fn() as jest.MockedFunction<typeof fetch>;
+    api = createAuthApi({ apiBase: API_BASE, fetchImpl: fetchSpy });
+  });
+
+  it("throws when apiBase is empty", () => {
+    expect(() => createAuthApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
+      "apiBase is required",
+    );
+  });
+
+  describe("login", () => {
+    it("posts credentials and returns the bearer token from the envelope", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "success", data: { token: TOKEN, token_type: "Bearer" } }) as Response,
+      );
+
+      const result = await api.login({ email: "taro@example.com", password: "password123" });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/user/login`,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ email: "taro@example.com", password: "password123" }),
+        }),
+      );
+      expect(result).toEqual({ token: TOKEN, tokenType: "Bearer" });
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(
+        api.login({ email: "taro@example.com", password: "wrong" }),
+      ).rejects.toThrow("HTTP 422");
+    });
+  });
+
+  describe("logout", () => {
+    it("posts to the logout endpoint with the bearer token", async () => {
+      fetchSpy.mockResolvedValue(makeOkResponse({}) as Response);
+
+      await api.logout(TOKEN);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/user/logout`,
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+        }),
+      );
+    });
+  });
+
+  describe("getCurrentUser", () => {
+    it("returns the current user on success", async () => {
+      const user = makeUser();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const result = await api.getCurrentUser(TOKEN);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/user/me`,
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+        }),
+      );
+      expect(result).toEqual(user);
+    });
+
+    it("returns null when unauthenticated (401)", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(401) as Response);
+
+      const result = await api.getCurrentUser(TOKEN);
+
+      expect(result).toBeNull();
+    });
+
+    it("throws on other HTTP errors", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(500) as Response);
+
+      await expect(api.getCurrentUser(TOKEN)).rejects.toThrow("HTTP 500");
+    });
+  });
+});

--- a/client/src/app/features/auth/apis/auth-api.test.ts
+++ b/client/src/app/features/auth/apis/auth-api.test.ts
@@ -46,7 +46,10 @@ describe("createAuthApi", () => {
   describe("login", () => {
     it("posts credentials and returns the bearer token from the envelope", async () => {
       fetchSpy.mockResolvedValue(
-        makeOkResponse({ status: "success", data: { token: TOKEN, token_type: "Bearer" } }) as Response,
+        makeOkResponse({
+          status: "success",
+          data: { token: TOKEN, token_type: "Bearer" },
+        }) as Response,
       );
 
       const result = await api.login({ email: "taro@example.com", password: "password123" });
@@ -64,9 +67,9 @@ describe("createAuthApi", () => {
     it("throws on HTTP error", async () => {
       fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
 
-      await expect(
-        api.login({ email: "taro@example.com", password: "wrong" }),
-      ).rejects.toThrow("HTTP 422");
+      await expect(api.login({ email: "taro@example.com", password: "wrong" })).rejects.toThrow(
+        "HTTP 422",
+      );
     });
   });
 

--- a/client/src/app/features/auth/apis/auth-api.ts
+++ b/client/src/app/features/auth/apis/auth-api.ts
@@ -1,0 +1,98 @@
+export type AuthApiDeps = {
+  apiBase: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type LoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type LoginResult = {
+  token: string;
+  tokenType: string;
+};
+
+export type ApiCurrentUserDto = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+};
+
+type ApiEnvelope<T> = {
+  status: string;
+  data: T;
+};
+
+const normalizeApiBase = (apiBase: string): string => apiBase.replace(/\/+$/, "");
+
+const withAuthHeader = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+});
+
+export const createAuthApi = ({ apiBase, fetchImpl = fetch }: AuthApiDeps) => {
+  if (!apiBase) {
+    throw new Error("apiBase is required");
+  }
+
+  const base = normalizeApiBase(apiBase);
+
+  return {
+    async login(request: LoginRequest, init?: RequestInit): Promise<LoginResult> {
+      const response = await fetchImpl(`${base}/api/v1/user/login`, {
+        ...init,
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          ...(init?.headers ?? {}),
+        },
+        body: JSON.stringify(request),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as ApiEnvelope<{ token: string; token_type: string }>;
+      return { token: body.data.token, tokenType: body.data.token_type };
+    },
+
+    async logout(token: string, init?: RequestInit): Promise<void> {
+      const response = await fetchImpl(`${base}/api/v1/user/logout`, {
+        ...init,
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          ...withAuthHeader(token),
+          ...(init?.headers ?? {}),
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+    },
+
+    async getCurrentUser(token: string, init?: RequestInit): Promise<ApiCurrentUserDto | null> {
+      const response = await fetchImpl(`${base}/api/v1/user/me`, {
+        ...init,
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          ...withAuthHeader(token),
+          ...(init?.headers ?? {}),
+        },
+      });
+
+      if (response.status === 401) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as ApiEnvelope<ApiCurrentUserDto>;
+      return body.data;
+    },
+  };
+};

--- a/client/src/app/features/auth/apis/index.ts
+++ b/client/src/app/features/auth/apis/index.ts
@@ -1,0 +1,13 @@
+import { createAuthApi } from "./auth-api.ts";
+
+const apiBase = import.meta.env.VITE_API_BASE_URL;
+
+if (!apiBase) {
+  throw new Error("VITE_API_BASE_URL is not set");
+}
+
+const authApi = createAuthApi({ apiBase });
+
+export const login = authApi.login;
+export const logout = authApi.logout;
+export const getCurrentUser = authApi.getCurrentUser;


### PR DESCRIPTION
## Summary
- Add `createAuthApi` (`login` / `logout` / `getCurrentUser`) targeting the real backend routes (`/api/v1/user/login`, `/api/v1/user/logout`, `/api/v1/user/me`)
- Backend auth is Sanctum in Bearer-token mode (confirmed against the running backend), not SPA cookie/CSRF — `login` returns a token, `logout`/`getCurrentUser` send `Authorization: Bearer <token>`

## Related
Part of #435 (types were split out separately into #433)

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/auth/apis`