### PR TITLE
feat(auth): add LoginForm UI component

### DIFF
--- a/client/src/app/features/auth/components/LoginForm.tsx
+++ b/client/src/app/features/auth/components/LoginForm.tsx
@@ -1,0 +1,54 @@
+import type { FormEvent } from "react";
+import TextField from "@shared/uis/TextField.tsx";
+import { Button } from "@shared/uis/Button.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import type { LoginFormValues } from "../types";
+
+type Props = {
+  value: LoginFormValues;
+  onChange: (next: LoginFormValues) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+  error: unknown;
+};
+
+export function LoginForm({ value, onChange, onSubmit, isLoading, error }: Props) {
+  const text = useText();
+
+  const handleField = <K extends keyof LoginFormValues>(key: K, next: LoginFormValues[K]) => {
+    onChange({ ...value, [key]: next });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-8">
+      <h1 className="text-xl font-bold">{text.login}</h1>
+
+      {error != null && <ErrorPanel message={text.loginError} />}
+
+      <TextField
+        label={text.userEmail}
+        type="email"
+        value={value.email}
+        onChange={(e) => handleField("email", e.target.value)}
+        required
+      />
+      <TextField
+        label={text.userPassword}
+        type="password"
+        value={value.password}
+        onChange={(e) => handleField("password", e.target.value)}
+        required
+      />
+
+      <Button type="submit" variant="primary" isLoading={isLoading}>
+        {text.login}
+      </Button>
+    </form>
+  );
+}

--- a/client/src/app/features/auth/components/__tests__/LoginForm.test.tsx
+++ b/client/src/app/features/auth/components/__tests__/LoginForm.test.tsx
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { LoginForm } from "../LoginForm";
+import type { LoginFormValues } from "../../types";
+
+const renderForm = (props: Partial<React.ComponentProps<typeof LoginForm>> = {}) => {
+  const value: LoginFormValues = { email: "", password: "" };
+
+  const defaultProps: React.ComponentProps<typeof LoginForm> = {
+    value,
+    onChange: jest.fn(),
+    onSubmit: jest.fn(),
+    isLoading: false,
+    error: null,
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <LoginForm {...defaultProps} />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe("LoginForm", () => {
+  it("renders email and password fields", () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/^Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+  });
+
+  it("calls onChange with the updated field when typing", () => {
+    const onChange = jest.fn();
+    renderForm({ onChange });
+
+    fireEvent.change(screen.getByLabelText(/^Email/), {
+      target: { value: "taro@example.com" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "taro@example.com", password: "" }),
+    );
+  });
+
+  it("calls onSubmit when the form is submitted", () => {
+    const onSubmit = jest.fn();
+    const value: LoginFormValues = { email: "taro@example.com", password: "password123" };
+    renderForm({ onSubmit, value });
+
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error panel when error is present", () => {
+    renderForm({ error: new Error("boom") });
+
+    expect(screen.getByText("Failed to log in.")).toBeInTheDocument();
+  });
+});

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -63,5 +63,9 @@
   "viewAllResults": "View all results",
   "unescoCriteriaSource": "UNESCO official criteria page",
   "worldHeritageBasics": "World Heritage Basics",
-  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means."
+  "worldHeritageBasicsDescription": "Every site is inscribed under one or more of these 10 selection criteria. Explore what each one means.",
+  "userEmail": "Email",
+  "userPassword": "Password",
+  "login": "Login",
+  "loginError": "Failed to log in."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -63,5 +63,9 @@
   "viewAllResults": "すべての結果を見る",
   "unescoCriteriaSource": "UNESCO 公式の登録基準ページ",
   "worldHeritageBasics": "世界遺産の基礎知識",
-  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。"
+  "worldHeritageBasicsDescription": "すべての世界遺産は、以下の10個の登録基準のいずれか（または複数）を満たして登録されています。各基準の意味を見てみましょう。",
+  "userEmail": "メールアドレス",
+  "userPassword": "パスワード",
+  "login": "ログイン",
+  "loginError": "ログインに失敗しました。"
 }


### PR DESCRIPTION
## Summary
- Add `LoginForm`, a controlled presentational component (`value` / `onChange` / `onSubmit` / `isLoading` / `error` props), following the same pattern as `UserCreateForm`
- Add `login` / `loginError` i18n keys, and `userEmail` / `userPassword` (reused from the create-user feature's field labels; this stack branched off `main` before that feature merged into `feat/user`, so they're added here too — same key/value, will reconcile cleanly)

## Why UI component before container
Shipped before `LoginContainer` (not after, as originally sequenced in #438/#439) so the container can depend on this component without a circular in-progress dependency — this bit us before on the create-user feature (see PR #409's history).

## Related
Part of #439

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/auth/components`