### PR TITLE
feat(user): add UserProfile type for the get-user feature

### DIFF
--- a/client/src/app/features/user/types.ts
+++ b/client/src/app/features/user/types.ts
@@ -10,3 +10,13 @@ export type CreateUserFormValues = {
   email: string;
   password: string;
 };
+
+export type UserProfile = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  ageRange: AgeRange;
+  subscriptionTier: SubscriptionTier;
+  subscriptionExpiresAt: string | null;
+};


### PR DESCRIPTION
## Summary
- Add `UserProfile`, a camelCase view model type for the get-user feature (`id`, `firstName`, `lastName`, `email`, `ageRange`, `subscriptionTier`, `subscriptionExpiresAt`)
- The existing `ApiUserDto` (`apis/user-api.ts`) already matches the backend's `GET /api/v1/users/{id}` response shape 1:1 and is reused as-is; `UserProfile` is the mapper's output type for the UI layer to consume

## Test plan
- [x] `npx tsc --noEmit`