### PR TITLE
feat(user): add get-user mapper, API client, and useGetUser hook

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -126,6 +126,39 @@ describe("createUserApi", () => {
     });
   });
 
+  describe("getUser", () => {
+    it("gets the user by id", async () => {
+      const user = makeUserDto();
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const out = await api.getUser(1);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${ENDPOINT}/1`,
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ Accept: "application/json" }),
+          credentials: "omit",
+        }),
+      );
+      expect(out).toEqual(user);
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(404) as Response);
+
+      await expect(api.getUser(1)).rejects.toThrow("HTTP 404");
+    });
+
+    it("throws when API status is not success", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "error", data: { message: "not found" } }) as Response,
+      );
+
+      await expect(api.getUser(1)).rejects.toThrow("API status is not success: error");
+    });
+  });
+
   it("throws when apiBase is empty", () => {
     expect(() => createUserApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
       "apiBase is required",

--- a/client/src/app/features/user/apis/index.ts
+++ b/client/src/app/features/user/apis/index.ts
@@ -9,3 +9,4 @@ if (!apiBase) {
 const userApi = createUserApi({ apiBase });
 
 export const createUser = userApi.createUser;
+export const getUser = userApi.getUser;

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -26,6 +26,10 @@ export type ApiCreateUserResponse =
   | { status: "success"; data: ApiUserDto }
   | { status: "error"; data: unknown };
 
+export type ApiGetUserResponse =
+  | { status: "success"; data: ApiUserDto }
+  | { status: "error"; data: unknown };
+
 const normalizeApiBase = (apiBase: string): string => apiBase.replace(/\/+$/, "");
 
 export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
@@ -48,6 +52,17 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
     signal: init?.signal,
   });
 
+  const withGetInit = (init?: RequestInit): RequestInit => ({
+    ...init,
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: init?.credentials ?? "omit",
+    signal: init?.signal,
+  });
+
   return {
     async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
       const response = await fetchImpl(endpoint, {
@@ -60,6 +75,21 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
       }
 
       const json = (await response.json()) as ApiCreateUserResponse;
+      if (json.status !== "success") {
+        throw new Error(`API status is not success: ${json.status}`);
+      }
+
+      return json.data;
+    },
+
+    async getUser(id: number, init?: RequestInit): Promise<ApiUserDto> {
+      const response = await fetchImpl(`${endpoint}/${id}`, withGetInit(init));
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = (await response.json()) as ApiGetUserResponse;
       if (json.status !== "success") {
         throw new Error(`API status is not success: ${json.status}`);
       }

--- a/client/src/app/features/user/hooks/__tests__/use-get-user.test.ts
+++ b/client/src/app/features/user/hooks/__tests__/use-get-user.test.ts
@@ -1,0 +1,177 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+jest.mock("../../apis", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("../../mapper/to-user-profile", () => ({
+  toUserProfile: jest.fn(),
+}));
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { useGetUser } from "../use-get-user";
+import { getUser } from "../../apis";
+import { toUserProfile } from "../../mapper/to-user-profile";
+import type { ApiUserDto } from "../../apis/user-api";
+import type { UserProfile } from "../../types";
+
+type GetFn = (id: number, opts?: { signal?: AbortSignal }) => Promise<ApiUserDto>;
+const getUserMock = getUser as unknown as jest.MockedFunction<GetFn>;
+
+type MapFn = (dto: ApiUserDto) => UserProfile;
+const toUserProfileMock = toUserProfile as unknown as jest.MockedFunction<MapFn>;
+
+const dto: ApiUserDto = {
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+};
+
+const profile: UserProfile = {
+  id: 1,
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useGetUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toUserProfileMock.mockReturnValue(profile);
+  });
+
+  test("初期状態: data=null, isLoading=true, error=null", () => {
+    getUserMock.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useGetUser(1));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("成功パス: mount時に getUser -> toUserProfile の順で呼ばれ、data に反映される", async () => {
+    const d = deferred<ApiUserDto>();
+    getUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useGetUser(1));
+
+    await act(async () => {
+      d.resolve(dto);
+      await d.promise;
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(profile);
+    expect(result.current.error).toBeNull();
+    expect(getUserMock).toHaveBeenCalledWith(1, expect.objectContaining({ signal: expect.any(Object) }));
+    expect(toUserProfileMock).toHaveBeenCalledWith(dto);
+  });
+
+  test("エラー: error に反映され、data は null のまま", async () => {
+    const boom = new Error("boom");
+    const d = deferred<ApiUserDto>();
+    getUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useGetUser(1));
+
+    await act(async () => {
+      d.reject(boom);
+      await d.promise.catch(() => {});
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe(boom);
+  });
+
+  test("AbortError は無視される（エラー状態にしない）", async () => {
+    const d = deferred<ApiUserDto>();
+    getUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useGetUser(1));
+
+    await act(async () => {
+      d.reject(new DOMException("Aborted", "AbortError"));
+      await d.promise.catch(() => {});
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  test("idが変わると前のリクエストを abort して再取得する", async () => {
+    const first = deferred<ApiUserDto>();
+    const second = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    getUserMock.mockImplementation((_id, opts) => {
+      signals.push(opts?.signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    const { result, rerender } = renderHook(({ id }) => useGetUser(id), {
+      initialProps: { id: 1 },
+    });
+
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    rerender({ id: 2 });
+
+    await waitFor(() => expect(signals).toHaveLength(2));
+    expect(signals[0]?.aborted).toBe(true);
+
+    await act(async () => {
+      second.resolve(dto);
+      await second.promise;
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(profile));
+    expect(getUserMock).toHaveBeenLastCalledWith(2, expect.objectContaining({ signal: expect.any(Object) }));
+  });
+
+  test("アンマウント時に現在のリクエストを abort する", () => {
+    const d = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    getUserMock.mockImplementation((_id, opts) => {
+      signals.push(opts?.signal);
+      return d.promise;
+    });
+
+    const { unmount } = renderHook(() => useGetUser(1));
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/client/src/app/features/user/hooks/use-get-user.ts
+++ b/client/src/app/features/user/hooks/use-get-user.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+import { getUser } from "../apis";
+import { toUserProfile } from "../mapper/to-user-profile";
+import type { UserProfile } from "../types";
+
+const isAbortError = (e: unknown): boolean => {
+  return e instanceof DOMException && e.name === "AbortError";
+};
+
+export function useGetUser(id: number) {
+  const [data, setData] = useState<UserProfile | null>(null);
+  const [isLoading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    abortRef.current?.abort();
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setLoading(true);
+    setError(null);
+
+    getUser(id, { signal: abortController.signal })
+      .then((dto) => setData(toUserProfile(dto)))
+      .catch((e) => {
+        if (!isAbortError(e)) setError(e);
+      })
+      .finally(() => setLoading(false));
+
+    return () => abortController.abort();
+  }, [id]);
+
+  return { data, isLoading, error };
+}

--- a/client/src/app/features/user/mapper/__tests__/to-user-profile.test.ts
+++ b/client/src/app/features/user/mapper/__tests__/to-user-profile.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+import { toUserProfile } from "../to-user-profile";
+import type { ApiUserDto } from "../../apis/user-api";
+
+const makeDto = (overrides: Partial<ApiUserDto> = {}): ApiUserDto => ({
+  id: 1,
+  first_name: "test",
+  last_name: "1234",
+  email: "test1234@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+  ...overrides,
+});
+
+describe("toUserProfile", () => {
+  it("maps the snake_case API DTO to a camelCase UserProfile", () => {
+    const profile = toUserProfile(makeDto());
+
+    expect(profile).toEqual({
+      id: 1,
+      firstName: "test",
+      lastName: "1234",
+      email: "test1234@example.com",
+      ageRange: "teens",
+      subscriptionTier: "free",
+      subscriptionExpiresAt: null,
+    });
+  });
+
+  it("preserves a non-null subscriptionExpiresAt", () => {
+    const profile = toUserProfile(makeDto({ subscription_expires_at: "2027-01-01" }));
+
+    expect(profile.subscriptionExpiresAt).toBe("2027-01-01");
+  });
+});

--- a/client/src/app/features/user/mapper/to-user-profile.ts
+++ b/client/src/app/features/user/mapper/to-user-profile.ts
@@ -1,0 +1,12 @@
+import type { ApiUserDto } from "../apis/user-api";
+import type { UserProfile } from "../types";
+
+export const toUserProfile = (dto: ApiUserDto): UserProfile => ({
+  id: dto.id,
+  firstName: dto.first_name,
+  lastName: dto.last_name,
+  email: dto.email,
+  ageRange: dto.age_range,
+  subscriptionTier: dto.subscription_tier,
+  subscriptionExpiresAt: dto.subscription_expires_at,
+});


### PR DESCRIPTION
## Summary
- `toUserProfile`: maps the API's `ApiUserDto` (snake_case, matches `GET /api/v1/users/{id}`) to the camelCase `UserProfile` view model
- `getUser(id)`: API client call to `GET /api/v1/users/{id}` (confirmed against the running backend; no auth required for this route)
- `useGetUser(id)`: fetches on mount and whenever `id` changes, maps the response through `toUserProfile`, exposes `{ data, isLoading, error }`; aborts the in-flight request on unmount and on `id` change

Builds on the `UserProfile` type from #447 (already merged into this branch).

## Related
Closes #411, #413

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/apis src/app/features/user/mapper src/app/features/user/hooks/__tests__/use-get-user.test.ts`