### PR TITLE
feat(user): add UserGetContainer

### DIFF
--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+import type { UserProfile } from "../../types";
+
+const useGetUserMock = jest.fn();
+
+jest.mock("../../hooks/use-get-user", () => ({
+  useGetUser: (id: number) => useGetUserMock(id),
+}));
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { UserGetContainer } from "../user-get-container";
+
+const profile: UserProfile = {
+  id: 1,
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};
+
+const renderContainer = (id = "1") =>
+  render(
+    <MemoryRouter initialEntries={[`/users/${id}`]}>
+      <LocaleProvider>
+        <Routes>
+          <Route path="/users/:id" element={<UserGetContainer />} />
+        </Routes>
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("UserGetContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders nothing while loading", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: true, error: null });
+
+    const { container } = renderContainer();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("passes the numeric id from the route to useGetUser", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer("42");
+
+    expect(useGetUserMock).toHaveBeenCalledWith(42);
+  });
+
+  it("renders the user profile on success", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer();
+
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.getByText("taro@example.com")).toBeInTheDocument();
+  });
+
+  it("shows an error panel when the hook reports an error", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: new Error("boom") });
+
+    renderContainer();
+
+    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+
+  it("shows an error panel when data is missing after loading", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    renderContainer();
+
+    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -1,6 +1,5 @@
 /** @jest-environment jsdom */
 
-import { jest } from "@jest/globals";
 import type { UserProfile } from "../../types";
 
 const useGetUserMock = jest.fn();
@@ -10,7 +9,6 @@ jest.mock("../../hooks/use-get-user", () => ({
 }));
 
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "@jest/globals";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserGetContainer } from "../user-get-container";

--- a/client/src/app/features/user/containers/user-get-container.tsx
+++ b/client/src/app/features/user/containers/user-get-container.tsx
@@ -1,0 +1,23 @@
+import { useParams } from "react-router-dom";
+import { useGetUser } from "../hooks/use-get-user";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+
+export function UserGetContainer() {
+  const { id } = useParams<{ id: string }>();
+  const { data, isLoading, error } = useGetUser(Number(id));
+  const text = useText();
+
+  if (isLoading) return null;
+  if (error || !data) return <ErrorPanel message={text.userGetError} />;
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-2 px-4 py-8">
+      <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
+      <p className="text-sm text-zinc-700">
+        {data.firstName} {data.lastName}
+      </p>
+      <p className="text-sm text-zinc-500">{data.email}</p>
+    </div>
+  );
+}

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -71,5 +71,7 @@
   "userPassword": "Password",
   "userCreateSubmit": "Create",
   "userCreateSuccess": "User created successfully.",
-  "userCreateError": "Failed to create user."
+  "userCreateError": "Failed to create user.",
+  "userProfileTitle": "User Profile",
+  "userGetError": "Failed to load user."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -71,5 +71,7 @@
   "userPassword": "パスワード",
   "userCreateSubmit": "作成",
   "userCreateSuccess": "ユーザーを作成しました。",
-  "userCreateError": "ユーザーの作成に失敗しました。"
+  "userCreateError": "ユーザーの作成に失敗しました。",
+  "userProfileTitle": "ユーザープロフィール",
+  "userGetError": "ユーザー情報の取得に失敗しました。"
 }


### PR DESCRIPTION
## Summary
- Add `UserGetContainer`: reads the `:id` route param, drives `useGetUser`, and renders the user's profile
- Renders nothing while loading, shows an `ErrorPanel` on error or when data is missing after loading
- Add `userProfileTitle` / `userGetError` i18n keys (en/ja)

## Related
Closes #414

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/containers/__tests__/user-get-container.test.tsx`
- [x] `npx prettier --check` on the touched files