### PR TITLE
feat(user): add UserProfileView UI component and wire `/users/:id` route

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -8,6 +8,7 @@ let fetchSpy: jest.MockedFunction<typeof fetch>;
 
 const API_BASE = "http://localhost:8700";
 const ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/user/create`;
+const USERS_ENDPOINT = `${API_BASE.replace(/\/+$/, "")}/api/v1/users`;
 
 const makeOkResponse = (body: ApiCreateUserResponse): MockResponse => ({
   ok: true,
@@ -134,7 +135,7 @@ describe("createUserApi", () => {
       const out = await api.getUser(1);
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${ENDPOINT}/1`,
+        `${USERS_ENDPOINT}/1`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({ Accept: "application/json" }),

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -38,7 +38,8 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
   }
 
   const base = normalizeApiBase(apiBase);
-  const endpoint = `${base}/api/v1/user/create`;
+  const createEndpoint = `${base}/api/v1/user/create`;
+  const usersEndpoint = `${base}/api/v1/users`;
 
   const withCommonInit = (init?: RequestInit): RequestInit => ({
     ...init,
@@ -65,7 +66,7 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
 
   return {
     async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
-      const response = await fetchImpl(endpoint, {
+      const response = await fetchImpl(createEndpoint, {
         ...withCommonInit(init),
         body: JSON.stringify(request),
       });
@@ -83,7 +84,7 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
     },
 
     async getUser(id: number, init?: RequestInit): Promise<ApiUserDto> {
-      const response = await fetchImpl(`${endpoint}/${id}`, withGetInit(init));
+      const response = await fetchImpl(`${usersEndpoint}/${id}`, withGetInit(init));
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/client/src/app/features/user/components/UserProfileView.tsx
+++ b/client/src/app/features/user/components/UserProfileView.tsx
@@ -1,0 +1,45 @@
+import { useText } from "@shared/locale/ui-text.ts";
+import type { UserProfile } from "../types";
+
+type Props = {
+  profile: UserProfile;
+};
+
+const initials = (firstName: string, lastName: string): string =>
+  `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+
+export function UserProfileView({ profile }: Props) {
+  const text = useText();
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col items-center gap-6 px-4 py-12">
+      <div className="flex h-24 w-24 items-center justify-center rounded-full bg-indigo-600 text-3xl font-semibold text-white">
+        {initials(profile.firstName, profile.lastName)}
+      </div>
+
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="text-2xl font-bold text-zinc-900">
+          {profile.firstName} {profile.lastName}
+        </h1>
+        <p className="text-sm text-zinc-500">{profile.email}</p>
+      </div>
+
+      <div className="w-full divide-y divide-zinc-200 rounded-2xl border border-zinc-200 bg-white/70 shadow-sm">
+        <ProfileRow label={text.userFirstName} value={profile.firstName} />
+        <ProfileRow label={text.userLastName} value={profile.lastName} />
+        <ProfileRow label={text.userEmail} value={profile.email} />
+        <ProfileRow label={text.userAgeRange} value={profile.ageRange} />
+        <ProfileRow label={text.userSubscriptionTier} value={profile.subscriptionTier} />
+      </div>
+    </div>
+  );
+}
+
+function ProfileRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between px-6 py-4">
+      <span className="text-sm font-medium text-zinc-500">{label}</span>
+      <span className="text-sm text-zinc-900">{value}</span>
+    </div>
+  );
+}

--- a/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { UserProfileView } from "../UserProfileView";
+import type { UserProfile } from "../../types";
+
+const profile: UserProfile = {
+  id: 1,
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};
+
+const renderView = (overrides: Partial<UserProfile> = {}) =>
+  render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <UserProfileView profile={{ ...profile, ...overrides }} />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("UserProfileView", () => {
+  it("renders the avatar initials from first and last name", () => {
+    renderView();
+
+    expect(screen.getByText("TY")).toBeInTheDocument();
+  });
+
+  it("renders the full name and email", () => {
+    renderView();
+
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
+  });
+
+  it("renders a profile row for each field", () => {
+    renderView();
+
+    expect(screen.getByText("First Name")).toBeInTheDocument();
+    expect(screen.getByText("Last Name")).toBeInTheDocument();
+    expect(screen.getByText("Age Range")).toBeInTheDocument();
+    expect(screen.getByText("teens")).toBeInTheDocument();
+    expect(screen.getByText("Subscription")).toBeInTheDocument();
+    expect(screen.getByText("free")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -39,12 +39,12 @@ describe("UserGetContainer", () => {
     jest.clearAllMocks();
   });
 
-  it("renders nothing while loading", () => {
+  it("shows a spinner while loading", () => {
     useGetUserMock.mockReturnValue({ data: null, isLoading: true, error: null });
 
-    const { container } = renderContainer();
+    renderContainer();
 
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
   });
 
   it("passes the numeric id from the route to useGetUser", () => {
@@ -61,7 +61,7 @@ describe("UserGetContainer", () => {
     renderContainer();
 
     expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
-    expect(screen.getByText("taro@example.com")).toBeInTheDocument();
+    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
   });
 
   it("shows an error panel when the hook reports an error", () => {

--- a/client/src/app/features/user/containers/user-get-container.tsx
+++ b/client/src/app/features/user/containers/user-get-container.tsx
@@ -1,6 +1,8 @@
 import { useParams } from "react-router-dom";
 import { useGetUser } from "../hooks/use-get-user";
+import { UserProfileView } from "../components/UserProfileView";
 import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { Spinner } from "@shared/uis/Spinner.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
 
 export function UserGetContainer() {
@@ -8,16 +10,8 @@ export function UserGetContainer() {
   const { data, isLoading, error } = useGetUser(Number(id));
   const text = useText();
 
-  if (isLoading) return null;
+  if (isLoading) return <Spinner />;
   if (error || !data) return <ErrorPanel message={text.userGetError} />;
 
-  return (
-    <div className="mx-auto flex max-w-xl flex-col gap-2 px-4 py-8">
-      <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
-      <p className="text-sm text-zinc-700">
-        {data.firstName} {data.lastName}
-      </p>
-      <p className="text-sm text-zinc-500">{data.email}</p>
-    </div>
-  );
+  return <UserProfileView profile={data} />;
 }

--- a/client/src/app/routes/AppRoutes.tsx
+++ b/client/src/app/routes/AppRoutes.tsx
@@ -5,6 +5,7 @@ import { CriteriaDetailContainer } from "@features/top/containers/criteria-detai
 import { HeritageGalleryContainer } from "@features/top/containers/heritage-gallery-container.tsx";
 import { SearchHeritageResultsContainer } from "@features/search/containers/search-heritage-result-container.tsx";
 import { UserCreateContainer } from "@features/user/containers/user-create-container.tsx";
+import { UserGetContainer } from "@features/user/containers/user-get-container.tsx";
 import { BreadcrumbProvider } from "@features/breadcrumbs/BreadCrumbProvider.tsx";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { AppLayout } from "@shared/layout/AppLayout.tsx";
@@ -21,6 +22,7 @@ export function AppRoutes() {
             <Route path="/heritages/:id/gallery" element={<HeritageGalleryContainer />} />
             <Route path="/heritages/:id" element={<WorldHeritageDetailContainer />} />
             <Route path="/users/new" element={<UserCreateContainer />} />
+            <Route path="/users/:id" element={<UserGetContainer />} />
             <Route path="*" element={<Navigate to="/heritages" replace />} />
           </Routes>
         </AppLayout>

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -73,5 +73,7 @@
   "userCreateSuccess": "User created successfully.",
   "userCreateError": "Failed to create user.",
   "userProfileTitle": "User Profile",
-  "userGetError": "Failed to load user."
+  "userGetError": "Failed to load user.",
+  "userAgeRange": "Age Range",
+  "userSubscriptionTier": "Subscription"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -73,5 +73,7 @@
   "userCreateSuccess": "ユーザーを作成しました。",
   "userCreateError": "ユーザーの作成に失敗しました。",
   "userProfileTitle": "ユーザープロフィール",
-  "userGetError": "ユーザー情報の取得に失敗しました。"
+  "userGetError": "ユーザー情報の取得に失敗しました。",
+  "userAgeRange": "年代",
+  "userSubscriptionTier": "サブスクリプション"
 }


### PR DESCRIPTION
## Summary
- Add `UserProfileView` presentational component to render a fetched user's profile
- Wire it into `UserGetContainer` (replacing the previous inline rendering) together with the shared `Spinner` for the loading state
- Add the `/users/:id` route to `AppRoutes.tsx`
- Add `userProfileTitle` presentational strings needed for the view (en/ja `ui.json`)
- Fix `getUser` endpoint definition to be separate from `createUser` (was previously sharing config, causing the wrong path/method for fetching a user)

## Related
Closes #415

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user`
- [x] `npx prettier --check` on the touched files