### PR TITLE
feat(user): Update User API frontend type

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { createUserApi } from "./user-api";
-import type { ApiCreateUserResponse, ApiUserDto, CreateUserRequest } from "./user-api";
+import type {
+  ApiCreateUserResponse,
+  ApiUserDto,
+  CreateUserRequest,
+  UpdateUserRequest,
+} from "./user-api";
 
 type MockResponse = Pick<Response, "ok" | "status" | "json">;
 
@@ -27,6 +32,13 @@ const makeRequest = (overrides: Partial<CreateUserRequest> = {}): CreateUserRequ
   last_name: "Yamada",
   email: "taro@example.com",
   password: "password123",
+  ...overrides,
+});
+
+const makeUpdateRequest = (overrides: Partial<UpdateUserRequest> = {}): UpdateUserRequest => ({
+  first_name: "Jiro",
+  last_name: "Sato",
+  email: "jiro@example2.com",
   ...overrides,
 });
 
@@ -157,6 +169,50 @@ describe("createUserApi", () => {
       );
 
       await expect(api.getUser(1)).rejects.toThrow("API status is not success: error");
+    });
+  });
+
+  describe("updateUser", () => {
+    it("patches the request body to the users endpoint", async () => {
+      const user = makeUserDto({
+        first_name: "Jiro",
+        last_name: "Sato",
+        email: "jiro@example2.com",
+      });
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const request = makeUpdateRequest();
+      const out = await api.updateUser(1, request);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${USERS_ENDPOINT}/1`,
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify(request),
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          }),
+          credentials: "omit",
+        }),
+      );
+      expect(out).toEqual(user);
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(api.updateUser(1, makeUpdateRequest())).rejects.toThrow("HTTP 422");
+    });
+
+    it("throws when API status is not success", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "error", data: { message: "invalid" } }) as Response,
+      );
+
+      await expect(api.updateUser(1, makeUpdateRequest())).rejects.toThrow(
+        "API status is not success: error",
+      );
     });
   });
 

--- a/client/src/app/features/user/apis/index.ts
+++ b/client/src/app/features/user/apis/index.ts
@@ -10,3 +10,4 @@ const userApi = createUserApi({ apiBase });
 
 export const createUser = userApi.createUser;
 export const getUser = userApi.getUser;
+export const updateUser = userApi.updateUser;

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -12,6 +12,12 @@ export type CreateUserRequest = {
   password: string;
 };
 
+export type UpdateUserRequest = {
+  first_name: string;
+  last_name: string;
+  email: string;
+};
+
 export type ApiUserDto = {
   id: number;
   first_name: string;
@@ -27,6 +33,10 @@ export type ApiCreateUserResponse =
   | { status: "error"; data: unknown };
 
 export type ApiGetUserResponse =
+  | { status: "success"; data: ApiUserDto }
+  | { status: "error"; data: unknown };
+
+export type ApiUpdateUserResponse =
   | { status: "success"; data: ApiUserDto }
   | { status: "error"; data: unknown };
 
@@ -64,6 +74,18 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
     signal: init?.signal,
   });
 
+  const withPatchInit = (init?: RequestInit): RequestInit => ({
+    ...init,
+    method: "PATCH",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: init?.credentials ?? "omit",
+    signal: init?.signal,
+  });
+
   return {
     async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
       const response = await fetchImpl(createEndpoint, {
@@ -91,6 +113,28 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
       }
 
       const json = (await response.json()) as ApiGetUserResponse;
+      if (json.status !== "success") {
+        throw new Error(`API status is not success: ${json.status}`);
+      }
+
+      return json.data;
+    },
+
+    async updateUser(
+      id: number,
+      request: UpdateUserRequest,
+      init?: RequestInit,
+    ): Promise<ApiUserDto> {
+      const response = await fetchImpl(`${usersEndpoint}/${id}`, {
+        ...withPatchInit(init),
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = (await response.json()) as ApiUpdateUserResponse;
       if (json.status !== "success") {
         throw new Error(`API status is not success: ${json.status}`);
       }


### PR DESCRIPTION
## Summary

### Description

- Add `UpdateUserRequest` / `ApiUpdateUserResponse` types and `updateUser(id, request)` to the user API client (`PATCH /api/v1/users/:id`)
- Editable fields are scoped below
    -  `first_name`
    - `last_name`
    - `email`

- `age_range` is immutable by design, `subscription_tier` changes are handled by a separate contract-aware flow
- Export `updateUser` from `apis/index.ts`