### PR TITLE
feat(user): add mapper from form values to update-user request

### DIFF
--- a/client/src/app/features/user/mapper/__tests__/to-update-user-request.test.ts
+++ b/client/src/app/features/user/mapper/__tests__/to-update-user-request.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+import { toUpdateUserRequest } from "../to-update-user-request";
+import type { UpdateUserFormValues } from "../to-update-user-request";
+
+const makeFormValues = (overrides: Partial<UpdateUserFormValues> = {}): UpdateUserFormValues => ({
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ...overrides,
+});
+
+describe("toUpdateUserRequest", () => {
+  it("maps camelCase form values to snake_case request fields", () => {
+    const request = toUpdateUserRequest(makeFormValues());
+
+    expect(request).toEqual({
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+    });
+  });
+
+  it("trims firstName, lastName, and email", () => {
+    const request = toUpdateUserRequest(
+      makeFormValues({
+        firstName: "  Taro  ",
+        lastName: "  Yamada  ",
+        email: "  taro@example.com  ",
+      }),
+    );
+
+    expect(request.first_name).toBe("Taro");
+    expect(request.last_name).toBe("Yamada");
+    expect(request.email).toBe("taro@example.com");
+  });
+});

--- a/client/src/app/features/user/mapper/to-update-user-request.ts
+++ b/client/src/app/features/user/mapper/to-update-user-request.ts
@@ -1,0 +1,10 @@
+import type { UserProfile } from "../types";
+import type { UpdateUserRequest } from "../apis/user-api";
+
+export type UpdateUserFormValues = Pick<UserProfile, "firstName" | "lastName" | "email">;
+
+export const toUpdateUserRequest = (values: UpdateUserFormValues): UpdateUserRequest => ({
+  first_name: values.firstName.trim(),
+  last_name: values.lastName.trim(),
+  email: values.email.trim(),
+});


### PR DESCRIPTION
## Summary
- Add `UpdateUserFormValues` (`Pick<UserProfile, "firstName" | "lastName" | "email">`) and `toUpdateUserRequest` mapper, converting camelCase form values to the snake_case `UpdateUserRequest` body
- `firstName` / `lastName` / `email` are trimmed, matching `toCreateUserRequest`

## Related
Closes #418

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/mapper`
- [x] `npx prettier --check` on the touched files