### PR TITLE
feat(user): wire user update into UserGetContainer and UserProfileView

### DIFF
--- a/client/src/app/features/user/components/UserProfileView.tsx
+++ b/client/src/app/features/user/components/UserProfileView.tsx
@@ -1,15 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import TextField from "@shared/uis/TextField.tsx";
+import { Button } from "@shared/uis/Button.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
 import type { UserProfile } from "../types";
+import type { UpdateUserFormValues } from "../mapper/to-update-user-request";
 
 type Props = {
   profile: UserProfile;
+  onUpdate: (values: UpdateUserFormValues) => void;
+  isUpdating: boolean;
+  updateError: unknown;
 };
 
 const initials = (firstName: string, lastName: string): string =>
   `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
-export function UserProfileView({ profile }: Props) {
+const toFormValues = (profile: UserProfile): UpdateUserFormValues => ({
+  firstName: profile.firstName,
+  lastName: profile.lastName,
+  email: profile.email,
+});
+
+export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: Props) {
   const text = useText();
+  const [isEditing, setIsEditing] = useState(false);
+  const [formValues, setFormValues] = useState<UpdateUserFormValues>(() => toFormValues(profile));
+  const wasUpdatingRef = useRef(false);
+
+  useEffect(() => {
+    if (wasUpdatingRef.current && !isUpdating && updateError == null) {
+      setIsEditing(false);
+    }
+    wasUpdatingRef.current = isUpdating;
+  }, [isUpdating, updateError]);
+
+  const handleField = <K extends keyof UpdateUserFormValues>(
+    key: K,
+    next: UpdateUserFormValues[K],
+  ) => {
+    setFormValues((prev) => ({ ...prev, [key]: next }));
+  };
+
+  const handleEdit = () => {
+    setFormValues(toFormValues(profile));
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onUpdate(formValues);
+  };
+
+  if (isEditing) {
+    return (
+      <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-12">
+        <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
+
+        {updateError != null && <ErrorPanel message={text.userUpdateError} />}
+
+        <TextField
+          label={text.userFirstName}
+          value={formValues.firstName}
+          onChange={(e) => handleField("firstName", e.target.value)}
+          required
+        />
+        <TextField
+          label={text.userLastName}
+          value={formValues.lastName}
+          onChange={(e) => handleField("lastName", e.target.value)}
+          required
+        />
+        <TextField
+          label={text.userEmail}
+          type="email"
+          value={formValues.email}
+          onChange={(e) => handleField("email", e.target.value)}
+          required
+        />
+
+        <div className="flex gap-3">
+          <Button type="submit" variant="primary" isLoading={isUpdating}>
+            {text.userUpdateSubmit}
+          </Button>
+          <Button type="button" variant="secondary" onClick={handleCancel} disabled={isUpdating}>
+            {text.userUpdateCancel}
+          </Button>
+        </div>
+      </form>
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-xl flex-col items-center gap-6 px-4 py-12">
@@ -31,6 +116,10 @@ export function UserProfileView({ profile }: Props) {
         <ProfileRow label={text.userAgeRange} value={profile.ageRange} />
         <ProfileRow label={text.userSubscriptionTier} value={profile.subscriptionTier} />
       </div>
+
+      <Button type="button" variant="secondary" onClick={handleEdit}>
+        {text.userUpdateEdit}
+      </Button>
     </div>
   );
 }

--- a/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserProfileView } from "../UserProfileView";
@@ -16,14 +16,23 @@ const profile: UserProfile = {
   subscriptionExpiresAt: null,
 };
 
-const renderView = (overrides: Partial<UserProfile> = {}) =>
-  render(
+const renderView = (props: Partial<React.ComponentProps<typeof UserProfileView>> = {}) => {
+  const defaultProps: React.ComponentProps<typeof UserProfileView> = {
+    profile,
+    onUpdate: jest.fn(),
+    isUpdating: false,
+    updateError: null,
+    ...props,
+  };
+
+  return render(
     <MemoryRouter>
       <LocaleProvider>
-        <UserProfileView profile={{ ...profile, ...overrides }} />
+        <UserProfileView {...defaultProps} />
       </LocaleProvider>
     </MemoryRouter>,
   );
+};
 
 describe("UserProfileView", () => {
   it("renders the avatar initials from first and last name", () => {
@@ -48,5 +57,92 @@ describe("UserProfileView", () => {
     expect(screen.getByText("teens")).toBeInTheDocument();
     expect(screen.getByText("Subscription")).toBeInTheDocument();
     expect(screen.getByText("free")).toBeInTheDocument();
+  });
+
+  it("switches to an edit form pre-filled with the current profile when Edit is clicked", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByLabelText(/^First Name/)).toHaveValue("Taro");
+    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
+    expect(screen.getByLabelText(/^Email/)).toHaveValue("taro@example.com");
+    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onUpdate with the edited values on save", () => {
+    const onUpdate = jest.fn();
+    renderView({ onUpdate });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      firstName: "Jiro",
+      lastName: "Yamada",
+      email: "taro@example.com",
+    });
+  });
+
+  it("returns to view mode when Cancel is clicked", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+  });
+
+  it("shows an error panel in edit mode when updateError is present", () => {
+    renderView({ updateError: new Error("boom") });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByText("Failed to update user.")).toBeInTheDocument();
+  });
+
+  it("stays in edit mode when isUpdating transitions to false with an error", () => {
+    const { rerender } = renderView({ isUpdating: true, updateError: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    rerender(
+      <MemoryRouter>
+        <LocaleProvider>
+          <UserProfileView
+            profile={profile}
+            onUpdate={jest.fn()}
+            isUpdating={false}
+            updateError={new Error("boom")}
+          />
+        </LocaleProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
+  });
+
+  it("returns to view mode when isUpdating transitions to false without an error", () => {
+    const { rerender } = renderView({ isUpdating: true, updateError: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    rerender(
+      <MemoryRouter>
+        <LocaleProvider>
+          <UserProfileView
+            profile={profile}
+            onUpdate={jest.fn()}
+            isUpdating={false}
+            updateError={null}
+          />
+        </LocaleProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -3,12 +3,17 @@
 import type { UserProfile } from "../../types";
 
 const useGetUserMock = jest.fn();
+const useUpdateUserMock = jest.fn();
 
 jest.mock("../../hooks/use-get-user", () => ({
   useGetUser: (id: number) => useGetUserMock(id),
 }));
 
-import { render, screen } from "@testing-library/react";
+jest.mock("../../hooks/use-update-user", () => ({
+  useUpdateUser: () => useUpdateUserMock(),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserGetContainer } from "../user-get-container";
@@ -35,8 +40,16 @@ const renderContainer = (id = "1") =>
   );
 
 describe("UserGetContainer", () => {
+  const submitMock = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    useUpdateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: null,
+      isLoading: false,
+      error: null,
+    });
   });
 
   it("shows a spinner while loading", () => {
@@ -78,5 +91,34 @@ describe("UserGetContainer", () => {
     renderContainer();
 
     expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+
+  it("calls useUpdateUser's submit with the numeric id and form values on save", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer("42");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ firstName: "Jiro", lastName: "Yamada", email: "taro@example.com" }),
+    );
+  });
+
+  it("reflects the updated profile immediately once useUpdateUser returns data", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+    useUpdateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: { ...profile, firstName: "Jiro" },
+      isLoading: false,
+      error: null,
+    });
+
+    renderContainer();
+
+    expect(screen.getByText("Jiro Yamada")).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/containers/user-get-container.tsx
+++ b/client/src/app/features/user/containers/user-get-container.tsx
@@ -1,17 +1,43 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useGetUser } from "../hooks/use-get-user";
+import { useUpdateUser } from "../hooks/use-update-user";
 import { UserProfileView } from "../components/UserProfileView";
 import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { Spinner } from "@shared/uis/Spinner.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
+import type { UserProfile } from "../types";
 
 export function UserGetContainer() {
   const { id } = useParams<{ id: string }>();
-  const { data, isLoading, error } = useGetUser(Number(id));
+  const numericId = Number(id);
+  const { data, isLoading, error } = useGetUser(numericId);
+  const {
+    submit: submitUpdate,
+    data: updated,
+    isLoading: isUpdating,
+    error: updateError,
+  } = useUpdateUser();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const text = useText();
 
-  if (isLoading) return <Spinner />;
-  if (error || !data) return <ErrorPanel message={text.userGetError} />;
+  useEffect(() => {
+    if (data) setProfile(data);
+  }, [data]);
 
-  return <UserProfileView profile={data} />;
+  useEffect(() => {
+    if (updated) setProfile(updated);
+  }, [updated]);
+
+  if (isLoading) return <Spinner />;
+  if (error || !profile) return <ErrorPanel message={text.userGetError} />;
+
+  return (
+    <UserProfileView
+      profile={profile}
+      onUpdate={(values) => submitUpdate(numericId, values)}
+      isUpdating={isUpdating}
+      updateError={updateError}
+    />
+  );
 }

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -75,5 +75,9 @@
   "userProfileTitle": "User Profile",
   "userGetError": "Failed to load user.",
   "userAgeRange": "Age Range",
-  "userSubscriptionTier": "Subscription"
+  "userSubscriptionTier": "Subscription",
+  "userUpdateEdit": "Edit",
+  "userUpdateSubmit": "Save",
+  "userUpdateCancel": "Cancel",
+  "userUpdateError": "Failed to update user."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -75,5 +75,9 @@
   "userProfileTitle": "ユーザープロフィール",
   "userGetError": "ユーザー情報の取得に失敗しました。",
   "userAgeRange": "年代",
-  "userSubscriptionTier": "サブスクリプション"
+  "userSubscriptionTier": "サブスクリプション",
+  "userUpdateEdit": "編集",
+  "userUpdateSubmit": "保存",
+  "userUpdateCancel": "キャンセル",
+  "userUpdateError": "ユーザー情報の更新に失敗しました。"
 }


### PR DESCRIPTION
## Summary
- Note: deviates from the original issue text (a standalone `UserUpdateContainer`) per the discussion on #420 — the `/users/:id` route and its `UserGetContainer` → `UserProfileView` hierarchy stay as-is, so update is wired into the existing get-feature files instead of new ones
- `UserGetContainer` now also calls `useUpdateUser` and holds the fetched profile as local state, overwriting it with the update result on success — this is what gives immediate reflection without a reload
- `UserProfileView` gains an edit mode: an "Edit" button switches to a form (firstName/lastName/email only — `ageRange`/`subscriptionTier` stay read-only), shows a loading state while `isUpdating`, shows an error panel via `updateError`, and returns to view mode automatically once the update succeeds (stays in edit mode on error)
- Add `userUpdateEdit` / `userUpdateSubmit` / `userUpdateCancel` / `userUpdateError` i18n keys (en/ja)

## Related
Closes #420

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user`
- [x] `npx prettier --check` on the touched files