### PR TITLE
feat(user): edit user profile fields individually in place

### DIFF
--- a/client/src/app/features/user/components/UserProfileView.tsx
+++ b/client/src/app/features/user/components/UserProfileView.tsx
@@ -14,6 +14,8 @@ type Props = {
   updateError: unknown;
 };
 
+type EditableField = keyof UpdateUserFormValues;
+
 const initials = (firstName: string, lastName: string): string =>
   `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
@@ -25,76 +27,31 @@ const toFormValues = (profile: UserProfile): UpdateUserFormValues => ({
 
 export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: Props) {
   const text = useText();
-  const [isEditing, setIsEditing] = useState(false);
-  const [formValues, setFormValues] = useState<UpdateUserFormValues>(() => toFormValues(profile));
+  const [editingField, setEditingField] = useState<EditableField | null>(null);
+  const [fieldValue, setFieldValue] = useState("");
   const wasUpdatingRef = useRef(false);
 
   useEffect(() => {
     if (wasUpdatingRef.current && !isUpdating && updateError == null) {
-      setIsEditing(false);
+      setEditingField(null);
     }
     wasUpdatingRef.current = isUpdating;
   }, [isUpdating, updateError]);
 
-  const handleField = <K extends keyof UpdateUserFormValues>(
-    key: K,
-    next: UpdateUserFormValues[K],
-  ) => {
-    setFormValues((prev) => ({ ...prev, [key]: next }));
+  const startEditing = (field: EditableField) => {
+    setFieldValue(profile[field]);
+    setEditingField(field);
   };
 
-  const handleEdit = () => {
-    setFormValues(toFormValues(profile));
-    setIsEditing(true);
+  const cancelEditing = () => {
+    setEditingField(null);
   };
 
-  const handleCancel = () => {
-    setIsEditing(false);
-  };
-
-  const handleSubmit = (e: FormEvent) => {
+  const handleSave = (e: FormEvent) => {
     e.preventDefault();
-    onUpdate(formValues);
+    if (!editingField) return;
+    onUpdate({ ...toFormValues(profile), [editingField]: fieldValue });
   };
-
-  if (isEditing) {
-    return (
-      <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-12">
-        <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
-
-        {updateError != null && <ErrorPanel message={text.userUpdateError} />}
-
-        <TextField
-          label={text.userFirstName}
-          value={formValues.firstName}
-          onChange={(e) => handleField("firstName", e.target.value)}
-          required
-        />
-        <TextField
-          label={text.userLastName}
-          value={formValues.lastName}
-          onChange={(e) => handleField("lastName", e.target.value)}
-          required
-        />
-        <TextField
-          label={text.userEmail}
-          type="email"
-          value={formValues.email}
-          onChange={(e) => handleField("email", e.target.value)}
-          required
-        />
-
-        <div className="flex gap-3">
-          <Button type="submit" variant="primary" isLoading={isUpdating}>
-            {text.userUpdateSubmit}
-          </Button>
-          <Button type="button" variant="secondary" onClick={handleCancel} disabled={isUpdating}>
-            {text.userUpdateCancel}
-          </Button>
-        </div>
-      </form>
-    );
-  }
 
   return (
     <div className="mx-auto flex max-w-xl flex-col items-center gap-6 px-4 py-12">
@@ -109,17 +66,58 @@ export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: 
         <p className="text-sm text-zinc-500">{profile.email}</p>
       </div>
 
+      {updateError != null && <ErrorPanel message={text.userUpdateError} />}
+
       <div className="w-full divide-y divide-zinc-200 rounded-2xl border border-zinc-200 bg-white/70 shadow-sm">
-        <ProfileRow label={text.userFirstName} value={profile.firstName} />
-        <ProfileRow label={text.userLastName} value={profile.lastName} />
-        <ProfileRow label={text.userEmail} value={profile.email} />
+        <EditableProfileRow
+          label={text.userFirstName}
+          value={profile.firstName}
+          isEditing={editingField === "firstName"}
+          isEditDisabled={isUpdating && editingField !== "firstName"}
+          isSaving={isUpdating && editingField === "firstName"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("firstName")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
+        <EditableProfileRow
+          label={text.userLastName}
+          value={profile.lastName}
+          isEditing={editingField === "lastName"}
+          isEditDisabled={isUpdating && editingField !== "lastName"}
+          isSaving={isUpdating && editingField === "lastName"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("lastName")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
+        <EditableProfileRow
+          label={text.userEmail}
+          value={profile.email}
+          type="email"
+          isEditing={editingField === "email"}
+          isEditDisabled={isUpdating && editingField !== "email"}
+          isSaving={isUpdating && editingField === "email"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("email")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
         <ProfileRow label={text.userAgeRange} value={profile.ageRange} />
         <ProfileRow label={text.userSubscriptionTier} value={profile.subscriptionTier} />
       </div>
-
-      <Button type="button" variant="secondary" onClick={handleEdit}>
-        {text.userUpdateEdit}
-      </Button>
     </div>
   );
 }
@@ -129,6 +127,88 @@ function ProfileRow({ label, value }: { label: string; value: string }) {
     <div className="flex items-center justify-between px-6 py-4">
       <span className="text-sm font-medium text-zinc-500">{label}</span>
       <span className="text-sm text-zinc-900">{value}</span>
+    </div>
+  );
+}
+
+type EditableProfileRowProps = {
+  label: string;
+  value: string;
+  type?: string;
+  isEditing: boolean;
+  isEditDisabled: boolean;
+  isSaving: boolean;
+  editValue: string;
+  onEditValueChange: (next: string) => void;
+  onStartEdit: () => void;
+  onCancel: () => void;
+  onSave: (e: FormEvent) => void;
+  editLabel: string;
+  saveLabel: string;
+  cancelLabel: string;
+};
+
+function EditableProfileRow({
+  label,
+  value,
+  type,
+  isEditing,
+  isEditDisabled,
+  isSaving,
+  editValue,
+  onEditValueChange,
+  onStartEdit,
+  onCancel,
+  onSave,
+  editLabel,
+  saveLabel,
+  cancelLabel,
+}: EditableProfileRowProps) {
+  if (isEditing) {
+    return (
+      <form onSubmit={onSave} className="flex items-center justify-between gap-3 px-6 py-4">
+        <TextField
+          label={label}
+          type={type}
+          value={editValue}
+          onChange={(e) => onEditValueChange(e.target.value)}
+          size="small"
+          required
+        />
+        <div className="flex shrink-0 gap-2">
+          <Button type="submit" variant="primary" size="sm" isLoading={isSaving}>
+            {saveLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            {cancelLabel}
+          </Button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between px-6 py-4">
+      <span className="text-sm font-medium text-zinc-500">{label}</span>
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-zinc-900">{value}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`${editLabel} ${label}`}
+          onClick={onStartEdit}
+          disabled={isEditDisabled}
+        >
+          {editLabel}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
@@ -48,7 +48,7 @@ describe("UserProfileView", () => {
     expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
   });
 
-  it("renders a profile row for each field", () => {
+  it("renders a profile row for each field, with an edit trigger only for editable ones", () => {
     renderView();
 
     expect(screen.getByText("First Name")).toBeInTheDocument();
@@ -57,24 +57,31 @@ describe("UserProfileView", () => {
     expect(screen.getByText("teens")).toBeInTheDocument();
     expect(screen.getByText("Subscription")).toBeInTheDocument();
     expect(screen.getByText("free")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit Last Name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit Email" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit Age Range" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit Subscription" })).not.toBeInTheDocument();
   });
 
-  it("switches to an edit form pre-filled with the current profile when Edit is clicked", () => {
+  it("turns only the selected field into an input, pre-filled with its current value", () => {
     renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
 
     expect(screen.getByLabelText(/^First Name/)).toHaveValue("Taro");
-    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
-    expect(screen.getByLabelText(/^Email/)).toHaveValue("taro@example.com");
-    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Last Name/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Email/)).not.toBeInTheDocument();
+    expect(screen.getByText("Yamada")).toBeInTheDocument();
+    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
   });
 
-  it("calls onUpdate with the edited values on save", () => {
+  it("calls onUpdate with the full field set, only the edited field changed, on save", () => {
     const onUpdate = jest.fn();
     renderView({ onUpdate });
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -85,64 +92,62 @@ describe("UserProfileView", () => {
     });
   });
 
+  it("switching to editing another field cancels the previous one", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit Last Name" }));
+
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
+  });
+
   it("returns to view mode when Cancel is clicked", () => {
     renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
     expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
   });
 
-  it("shows an error panel in edit mode when updateError is present", () => {
+  it("shows an error panel when updateError is present", () => {
     renderView({ updateError: new Error("boom") });
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
     expect(screen.getByText("Failed to update user.")).toBeInTheDocument();
   });
 
-  it("stays in edit mode when isUpdating transitions to false with an error", () => {
-    const { rerender } = renderView({ isUpdating: true, updateError: null });
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
+  const rerenderWith = (
+    rerender: (ui: React.ReactElement) => void,
+    props: { isUpdating: boolean; updateError: unknown },
+  ) =>
     rerender(
       <MemoryRouter>
         <LocaleProvider>
-          <UserProfileView
-            profile={profile}
-            onUpdate={jest.fn()}
-            isUpdating={false}
-            updateError={new Error("boom")}
-          />
+          <UserProfileView profile={profile} onUpdate={jest.fn()} {...props} />
         </LocaleProvider>
       </MemoryRouter>,
     );
+
+  it("stays in edit mode when isUpdating transitions to false with an error", () => {
+    const { rerender } = renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    rerenderWith(rerender, { isUpdating: true, updateError: null });
+    rerenderWith(rerender, { isUpdating: false, updateError: new Error("boom") });
 
     expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
   });
 
   it("returns to view mode when isUpdating transitions to false without an error", () => {
-    const { rerender } = renderView({ isUpdating: true, updateError: null });
+    const { rerender } = renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
-    rerender(
-      <MemoryRouter>
-        <LocaleProvider>
-          <UserProfileView
-            profile={profile}
-            onUpdate={jest.fn()}
-            isUpdating={false}
-            updateError={null}
-          />
-        </LocaleProvider>
-      </MemoryRouter>,
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    rerenderWith(rerender, { isUpdating: true, updateError: null });
+    rerenderWith(rerender, { isUpdating: false, updateError: null });
 
     expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
-    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -98,7 +98,7 @@ describe("UserGetContainer", () => {
 
     renderContainer("42");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 


### PR DESCRIPTION
## Summary
- Note: deviates from the original issue text (`UserUpdateForm` + a new `/users/:id/edit` route) — no separate update screen exists; editing happens in place on `/users/:id` per prior discussion
- `UserProfileView` now offers per-field editing for `firstName` / `lastName` / `email`: clicking a row's "Edit" button turns only that row into an input (pre-filled with its current value), while the other rows stay as plain text; `ageRange` / `subscriptionTier` have no edit affordance (not editable)
- Saving a field submits the full editable field set with just that one field changed, since the API updates all three together
- Switching to edit another field discards the in-progress edit of the previous one; editing is blocked on other fields while a save is in flight
- Validation is left to HTML5 (`required` / `type="email"` on the input) — no JS validation library wired in yet, per discussion
- Verified manually in the browser: editing a field and saving updates the profile immediately, no reload

## Related
Closes #421

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user`
- [x] `npx prettier --check` on the touched files
- [x] Manually verified in the browser