### PR TITLE
feat(user): User Information Update Method

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { createUserApi } from "./user-api";
-import type { ApiCreateUserResponse, ApiUserDto, CreateUserRequest } from "./user-api";
+import type {
+  ApiCreateUserResponse,
+  ApiUserDto,
+  CreateUserRequest,
+  UpdateUserRequest,
+} from "./user-api";
 
 type MockResponse = Pick<Response, "ok" | "status" | "json">;
 
@@ -27,6 +32,13 @@ const makeRequest = (overrides: Partial<CreateUserRequest> = {}): CreateUserRequ
   last_name: "Yamada",
   email: "taro@example.com",
   password: "password123",
+  ...overrides,
+});
+
+const makeUpdateRequest = (overrides: Partial<UpdateUserRequest> = {}): UpdateUserRequest => ({
+  first_name: "Jiro",
+  last_name: "Sato",
+  email: "jiro@example2.com",
   ...overrides,
 });
 
@@ -157,6 +169,50 @@ describe("createUserApi", () => {
       );
 
       await expect(api.getUser(1)).rejects.toThrow("API status is not success: error");
+    });
+  });
+
+  describe("updateUser", () => {
+    it("patches the request body to the users endpoint", async () => {
+      const user = makeUserDto({
+        first_name: "Jiro",
+        last_name: "Sato",
+        email: "jiro@example2.com",
+      });
+      fetchSpy.mockResolvedValue(makeOkResponse({ status: "success", data: user }) as Response);
+
+      const request = makeUpdateRequest();
+      const out = await api.updateUser(1, request);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${USERS_ENDPOINT}/1`,
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify(request),
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          }),
+          credentials: "omit",
+        }),
+      );
+      expect(out).toEqual(user);
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(api.updateUser(1, makeUpdateRequest())).rejects.toThrow("HTTP 422");
+    });
+
+    it("throws when API status is not success", async () => {
+      fetchSpy.mockResolvedValue(
+        makeOkResponse({ status: "error", data: { message: "invalid" } }) as Response,
+      );
+
+      await expect(api.updateUser(1, makeUpdateRequest())).rejects.toThrow(
+        "API status is not success: error",
+      );
     });
   });
 

--- a/client/src/app/features/user/apis/index.ts
+++ b/client/src/app/features/user/apis/index.ts
@@ -10,3 +10,4 @@ const userApi = createUserApi({ apiBase });
 
 export const createUser = userApi.createUser;
 export const getUser = userApi.getUser;
+export const updateUser = userApi.updateUser;

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -12,6 +12,12 @@ export type CreateUserRequest = {
   password: string;
 };
 
+export type UpdateUserRequest = {
+  first_name: string;
+  last_name: string;
+  email: string;
+};
+
 export type ApiUserDto = {
   id: number;
   first_name: string;
@@ -27,6 +33,10 @@ export type ApiCreateUserResponse =
   | { status: "error"; data: unknown };
 
 export type ApiGetUserResponse =
+  | { status: "success"; data: ApiUserDto }
+  | { status: "error"; data: unknown };
+
+export type ApiUpdateUserResponse =
   | { status: "success"; data: ApiUserDto }
   | { status: "error"; data: unknown };
 
@@ -64,6 +74,18 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
     signal: init?.signal,
   });
 
+  const withPatchInit = (init?: RequestInit): RequestInit => ({
+    ...init,
+    method: "PATCH",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: init?.credentials ?? "omit",
+    signal: init?.signal,
+  });
+
   return {
     async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
       const response = await fetchImpl(createEndpoint, {
@@ -91,6 +113,28 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
       }
 
       const json = (await response.json()) as ApiGetUserResponse;
+      if (json.status !== "success") {
+        throw new Error(`API status is not success: ${json.status}`);
+      }
+
+      return json.data;
+    },
+
+    async updateUser(
+      id: number,
+      request: UpdateUserRequest,
+      init?: RequestInit,
+    ): Promise<ApiUserDto> {
+      const response = await fetchImpl(`${usersEndpoint}/${id}`, {
+        ...withPatchInit(init),
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = (await response.json()) as ApiUpdateUserResponse;
       if (json.status !== "success") {
         throw new Error(`API status is not success: ${json.status}`);
       }

--- a/client/src/app/features/user/components/UserProfileView.tsx
+++ b/client/src/app/features/user/components/UserProfileView.tsx
@@ -1,15 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import TextField from "@shared/uis/TextField.tsx";
+import { Button } from "@shared/uis/Button.tsx";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
 import type { UserProfile } from "../types";
+import type { UpdateUserFormValues } from "../mapper/to-update-user-request";
 
 type Props = {
   profile: UserProfile;
+  onUpdate: (values: UpdateUserFormValues) => void;
+  isUpdating: boolean;
+  updateError: unknown;
 };
 
 const initials = (firstName: string, lastName: string): string =>
   `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
-export function UserProfileView({ profile }: Props) {
+const toFormValues = (profile: UserProfile): UpdateUserFormValues => ({
+  firstName: profile.firstName,
+  lastName: profile.lastName,
+  email: profile.email,
+});
+
+export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: Props) {
   const text = useText();
+  const [isEditing, setIsEditing] = useState(false);
+  const [formValues, setFormValues] = useState<UpdateUserFormValues>(() => toFormValues(profile));
+  const wasUpdatingRef = useRef(false);
+
+  useEffect(() => {
+    if (wasUpdatingRef.current && !isUpdating && updateError == null) {
+      setIsEditing(false);
+    }
+    wasUpdatingRef.current = isUpdating;
+  }, [isUpdating, updateError]);
+
+  const handleField = <K extends keyof UpdateUserFormValues>(
+    key: K,
+    next: UpdateUserFormValues[K],
+  ) => {
+    setFormValues((prev) => ({ ...prev, [key]: next }));
+  };
+
+  const handleEdit = () => {
+    setFormValues(toFormValues(profile));
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onUpdate(formValues);
+  };
+
+  if (isEditing) {
+    return (
+      <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-12">
+        <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
+
+        {updateError != null && <ErrorPanel message={text.userUpdateError} />}
+
+        <TextField
+          label={text.userFirstName}
+          value={formValues.firstName}
+          onChange={(e) => handleField("firstName", e.target.value)}
+          required
+        />
+        <TextField
+          label={text.userLastName}
+          value={formValues.lastName}
+          onChange={(e) => handleField("lastName", e.target.value)}
+          required
+        />
+        <TextField
+          label={text.userEmail}
+          type="email"
+          value={formValues.email}
+          onChange={(e) => handleField("email", e.target.value)}
+          required
+        />
+
+        <div className="flex gap-3">
+          <Button type="submit" variant="primary" isLoading={isUpdating}>
+            {text.userUpdateSubmit}
+          </Button>
+          <Button type="button" variant="secondary" onClick={handleCancel} disabled={isUpdating}>
+            {text.userUpdateCancel}
+          </Button>
+        </div>
+      </form>
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-xl flex-col items-center gap-6 px-4 py-12">
@@ -31,6 +116,10 @@ export function UserProfileView({ profile }: Props) {
         <ProfileRow label={text.userAgeRange} value={profile.ageRange} />
         <ProfileRow label={text.userSubscriptionTier} value={profile.subscriptionTier} />
       </div>
+
+      <Button type="button" variant="secondary" onClick={handleEdit}>
+        {text.userUpdateEdit}
+      </Button>
     </div>
   );
 }

--- a/client/src/app/features/user/components/UserProfileView.tsx
+++ b/client/src/app/features/user/components/UserProfileView.tsx
@@ -14,6 +14,8 @@ type Props = {
   updateError: unknown;
 };
 
+type EditableField = keyof UpdateUserFormValues;
+
 const initials = (firstName: string, lastName: string): string =>
   `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
@@ -25,76 +27,31 @@ const toFormValues = (profile: UserProfile): UpdateUserFormValues => ({
 
 export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: Props) {
   const text = useText();
-  const [isEditing, setIsEditing] = useState(false);
-  const [formValues, setFormValues] = useState<UpdateUserFormValues>(() => toFormValues(profile));
+  const [editingField, setEditingField] = useState<EditableField | null>(null);
+  const [fieldValue, setFieldValue] = useState("");
   const wasUpdatingRef = useRef(false);
 
   useEffect(() => {
     if (wasUpdatingRef.current && !isUpdating && updateError == null) {
-      setIsEditing(false);
+      setEditingField(null);
     }
     wasUpdatingRef.current = isUpdating;
   }, [isUpdating, updateError]);
 
-  const handleField = <K extends keyof UpdateUserFormValues>(
-    key: K,
-    next: UpdateUserFormValues[K],
-  ) => {
-    setFormValues((prev) => ({ ...prev, [key]: next }));
+  const startEditing = (field: EditableField) => {
+    setFieldValue(profile[field]);
+    setEditingField(field);
   };
 
-  const handleEdit = () => {
-    setFormValues(toFormValues(profile));
-    setIsEditing(true);
+  const cancelEditing = () => {
+    setEditingField(null);
   };
 
-  const handleCancel = () => {
-    setIsEditing(false);
-  };
-
-  const handleSubmit = (e: FormEvent) => {
+  const handleSave = (e: FormEvent) => {
     e.preventDefault();
-    onUpdate(formValues);
+    if (!editingField) return;
+    onUpdate({ ...toFormValues(profile), [editingField]: fieldValue });
   };
-
-  if (isEditing) {
-    return (
-      <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 px-4 py-12">
-        <h1 className="text-xl font-bold">{text.userProfileTitle}</h1>
-
-        {updateError != null && <ErrorPanel message={text.userUpdateError} />}
-
-        <TextField
-          label={text.userFirstName}
-          value={formValues.firstName}
-          onChange={(e) => handleField("firstName", e.target.value)}
-          required
-        />
-        <TextField
-          label={text.userLastName}
-          value={formValues.lastName}
-          onChange={(e) => handleField("lastName", e.target.value)}
-          required
-        />
-        <TextField
-          label={text.userEmail}
-          type="email"
-          value={formValues.email}
-          onChange={(e) => handleField("email", e.target.value)}
-          required
-        />
-
-        <div className="flex gap-3">
-          <Button type="submit" variant="primary" isLoading={isUpdating}>
-            {text.userUpdateSubmit}
-          </Button>
-          <Button type="button" variant="secondary" onClick={handleCancel} disabled={isUpdating}>
-            {text.userUpdateCancel}
-          </Button>
-        </div>
-      </form>
-    );
-  }
 
   return (
     <div className="mx-auto flex max-w-xl flex-col items-center gap-6 px-4 py-12">
@@ -109,17 +66,58 @@ export function UserProfileView({ profile, onUpdate, isUpdating, updateError }: 
         <p className="text-sm text-zinc-500">{profile.email}</p>
       </div>
 
+      {updateError != null && <ErrorPanel message={text.userUpdateError} />}
+
       <div className="w-full divide-y divide-zinc-200 rounded-2xl border border-zinc-200 bg-white/70 shadow-sm">
-        <ProfileRow label={text.userFirstName} value={profile.firstName} />
-        <ProfileRow label={text.userLastName} value={profile.lastName} />
-        <ProfileRow label={text.userEmail} value={profile.email} />
+        <EditableProfileRow
+          label={text.userFirstName}
+          value={profile.firstName}
+          isEditing={editingField === "firstName"}
+          isEditDisabled={isUpdating && editingField !== "firstName"}
+          isSaving={isUpdating && editingField === "firstName"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("firstName")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
+        <EditableProfileRow
+          label={text.userLastName}
+          value={profile.lastName}
+          isEditing={editingField === "lastName"}
+          isEditDisabled={isUpdating && editingField !== "lastName"}
+          isSaving={isUpdating && editingField === "lastName"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("lastName")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
+        <EditableProfileRow
+          label={text.userEmail}
+          value={profile.email}
+          type="email"
+          isEditing={editingField === "email"}
+          isEditDisabled={isUpdating && editingField !== "email"}
+          isSaving={isUpdating && editingField === "email"}
+          editValue={fieldValue}
+          onEditValueChange={setFieldValue}
+          onStartEdit={() => startEditing("email")}
+          onCancel={cancelEditing}
+          onSave={handleSave}
+          editLabel={text.userUpdateEdit}
+          saveLabel={text.userUpdateSubmit}
+          cancelLabel={text.userUpdateCancel}
+        />
         <ProfileRow label={text.userAgeRange} value={profile.ageRange} />
         <ProfileRow label={text.userSubscriptionTier} value={profile.subscriptionTier} />
       </div>
-
-      <Button type="button" variant="secondary" onClick={handleEdit}>
-        {text.userUpdateEdit}
-      </Button>
     </div>
   );
 }
@@ -129,6 +127,88 @@ function ProfileRow({ label, value }: { label: string; value: string }) {
     <div className="flex items-center justify-between px-6 py-4">
       <span className="text-sm font-medium text-zinc-500">{label}</span>
       <span className="text-sm text-zinc-900">{value}</span>
+    </div>
+  );
+}
+
+type EditableProfileRowProps = {
+  label: string;
+  value: string;
+  type?: string;
+  isEditing: boolean;
+  isEditDisabled: boolean;
+  isSaving: boolean;
+  editValue: string;
+  onEditValueChange: (next: string) => void;
+  onStartEdit: () => void;
+  onCancel: () => void;
+  onSave: (e: FormEvent) => void;
+  editLabel: string;
+  saveLabel: string;
+  cancelLabel: string;
+};
+
+function EditableProfileRow({
+  label,
+  value,
+  type,
+  isEditing,
+  isEditDisabled,
+  isSaving,
+  editValue,
+  onEditValueChange,
+  onStartEdit,
+  onCancel,
+  onSave,
+  editLabel,
+  saveLabel,
+  cancelLabel,
+}: EditableProfileRowProps) {
+  if (isEditing) {
+    return (
+      <form onSubmit={onSave} className="flex items-center justify-between gap-3 px-6 py-4">
+        <TextField
+          label={label}
+          type={type}
+          value={editValue}
+          onChange={(e) => onEditValueChange(e.target.value)}
+          size="small"
+          required
+        />
+        <div className="flex shrink-0 gap-2">
+          <Button type="submit" variant="primary" size="sm" isLoading={isSaving}>
+            {saveLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            {cancelLabel}
+          </Button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between px-6 py-4">
+      <span className="text-sm font-medium text-zinc-500">{label}</span>
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-zinc-900">{value}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`${editLabel} ${label}`}
+          onClick={onStartEdit}
+          disabled={isEditDisabled}
+        >
+          {editLabel}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
@@ -48,7 +48,7 @@ describe("UserProfileView", () => {
     expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
   });
 
-  it("renders a profile row for each field", () => {
+  it("renders a profile row for each field, with an edit trigger only for editable ones", () => {
     renderView();
 
     expect(screen.getByText("First Name")).toBeInTheDocument();
@@ -57,24 +57,31 @@ describe("UserProfileView", () => {
     expect(screen.getByText("teens")).toBeInTheDocument();
     expect(screen.getByText("Subscription")).toBeInTheDocument();
     expect(screen.getByText("free")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit Last Name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit Email" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit Age Range" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit Subscription" })).not.toBeInTheDocument();
   });
 
-  it("switches to an edit form pre-filled with the current profile when Edit is clicked", () => {
+  it("turns only the selected field into an input, pre-filled with its current value", () => {
     renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
 
     expect(screen.getByLabelText(/^First Name/)).toHaveValue("Taro");
-    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
-    expect(screen.getByLabelText(/^Email/)).toHaveValue("taro@example.com");
-    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Last Name/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Email/)).not.toBeInTheDocument();
+    expect(screen.getByText("Yamada")).toBeInTheDocument();
+    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
   });
 
-  it("calls onUpdate with the edited values on save", () => {
+  it("calls onUpdate with the full field set, only the edited field changed, on save", () => {
     const onUpdate = jest.fn();
     renderView({ onUpdate });
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -85,64 +92,62 @@ describe("UserProfileView", () => {
     });
   });
 
+  it("switching to editing another field cancels the previous one", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit Last Name" }));
+
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
+  });
+
   it("returns to view mode when Cancel is clicked", () => {
     renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
     expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
   });
 
-  it("shows an error panel in edit mode when updateError is present", () => {
+  it("shows an error panel when updateError is present", () => {
     renderView({ updateError: new Error("boom") });
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
     expect(screen.getByText("Failed to update user.")).toBeInTheDocument();
   });
 
-  it("stays in edit mode when isUpdating transitions to false with an error", () => {
-    const { rerender } = renderView({ isUpdating: true, updateError: null });
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
+  const rerenderWith = (
+    rerender: (ui: React.ReactElement) => void,
+    props: { isUpdating: boolean; updateError: unknown },
+  ) =>
     rerender(
       <MemoryRouter>
         <LocaleProvider>
-          <UserProfileView
-            profile={profile}
-            onUpdate={jest.fn()}
-            isUpdating={false}
-            updateError={new Error("boom")}
-          />
+          <UserProfileView profile={profile} onUpdate={jest.fn()} {...props} />
         </LocaleProvider>
       </MemoryRouter>,
     );
+
+  it("stays in edit mode when isUpdating transitions to false with an error", () => {
+    const { rerender } = renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    rerenderWith(rerender, { isUpdating: true, updateError: null });
+    rerenderWith(rerender, { isUpdating: false, updateError: new Error("boom") });
 
     expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
   });
 
   it("returns to view mode when isUpdating transitions to false without an error", () => {
-    const { rerender } = renderView({ isUpdating: true, updateError: null });
+    const { rerender } = renderView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
-    rerender(
-      <MemoryRouter>
-        <LocaleProvider>
-          <UserProfileView
-            profile={profile}
-            onUpdate={jest.fn()}
-            isUpdating={false}
-            updateError={null}
-          />
-        </LocaleProvider>
-      </MemoryRouter>,
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    rerenderWith(rerender, { isUpdating: true, updateError: null });
+    rerenderWith(rerender, { isUpdating: false, updateError: null });
 
     expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
-    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit First Name" })).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
+++ b/client/src/app/features/user/components/__tests__/UserProfileView.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserProfileView } from "../UserProfileView";
@@ -16,14 +16,23 @@ const profile: UserProfile = {
   subscriptionExpiresAt: null,
 };
 
-const renderView = (overrides: Partial<UserProfile> = {}) =>
-  render(
+const renderView = (props: Partial<React.ComponentProps<typeof UserProfileView>> = {}) => {
+  const defaultProps: React.ComponentProps<typeof UserProfileView> = {
+    profile,
+    onUpdate: jest.fn(),
+    isUpdating: false,
+    updateError: null,
+    ...props,
+  };
+
+  return render(
     <MemoryRouter>
       <LocaleProvider>
-        <UserProfileView profile={{ ...profile, ...overrides }} />
+        <UserProfileView {...defaultProps} />
       </LocaleProvider>
     </MemoryRouter>,
   );
+};
 
 describe("UserProfileView", () => {
   it("renders the avatar initials from first and last name", () => {
@@ -48,5 +57,92 @@ describe("UserProfileView", () => {
     expect(screen.getByText("teens")).toBeInTheDocument();
     expect(screen.getByText("Subscription")).toBeInTheDocument();
     expect(screen.getByText("free")).toBeInTheDocument();
+  });
+
+  it("switches to an edit form pre-filled with the current profile when Edit is clicked", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByLabelText(/^First Name/)).toHaveValue("Taro");
+    expect(screen.getByLabelText(/^Last Name/)).toHaveValue("Yamada");
+    expect(screen.getByLabelText(/^Email/)).toHaveValue("taro@example.com");
+    expect(screen.queryByLabelText(/age range/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onUpdate with the edited values on save", () => {
+    const onUpdate = jest.fn();
+    renderView({ onUpdate });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      firstName: "Jiro",
+      lastName: "Yamada",
+      email: "taro@example.com",
+    });
+  });
+
+  it("returns to view mode when Cancel is clicked", () => {
+    renderView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+  });
+
+  it("shows an error panel in edit mode when updateError is present", () => {
+    renderView({ updateError: new Error("boom") });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByText("Failed to update user.")).toBeInTheDocument();
+  });
+
+  it("stays in edit mode when isUpdating transitions to false with an error", () => {
+    const { rerender } = renderView({ isUpdating: true, updateError: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    rerender(
+      <MemoryRouter>
+        <LocaleProvider>
+          <UserProfileView
+            profile={profile}
+            onUpdate={jest.fn()}
+            isUpdating={false}
+            updateError={new Error("boom")}
+          />
+        </LocaleProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/^First Name/)).toBeInTheDocument();
+  });
+
+  it("returns to view mode when isUpdating transitions to false without an error", () => {
+    const { rerender } = renderView({ isUpdating: true, updateError: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    rerender(
+      <MemoryRouter>
+        <LocaleProvider>
+          <UserProfileView
+            profile={profile}
+            onUpdate={jest.fn()}
+            isUpdating={false}
+            updateError={null}
+          />
+        </LocaleProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText(/^First Name/)).not.toBeInTheDocument();
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -3,12 +3,17 @@
 import type { UserProfile } from "../../types";
 
 const useGetUserMock = jest.fn();
+const useUpdateUserMock = jest.fn();
 
 jest.mock("../../hooks/use-get-user", () => ({
   useGetUser: (id: number) => useGetUserMock(id),
 }));
 
-import { render, screen } from "@testing-library/react";
+jest.mock("../../hooks/use-update-user", () => ({
+  useUpdateUser: () => useUpdateUserMock(),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserGetContainer } from "../user-get-container";
@@ -35,8 +40,16 @@ const renderContainer = (id = "1") =>
   );
 
 describe("UserGetContainer", () => {
+  const submitMock = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
+    useUpdateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: null,
+      isLoading: false,
+      error: null,
+    });
   });
 
   it("shows a spinner while loading", () => {
@@ -78,5 +91,34 @@ describe("UserGetContainer", () => {
     renderContainer();
 
     expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+
+  it("calls useUpdateUser's submit with the numeric id and form values on save", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer("42");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ firstName: "Jiro", lastName: "Yamada", email: "taro@example.com" }),
+    );
+  });
+
+  it("reflects the updated profile immediately once useUpdateUser returns data", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+    useUpdateUserMock.mockReturnValue({
+      submit: submitMock,
+      data: { ...profile, firstName: "Jiro" },
+      isLoading: false,
+      error: null,
+    });
+
+    renderContainer();
+
+    expect(screen.getByText("Jiro Yamada")).toBeInTheDocument();
   });
 });

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -98,7 +98,7 @@ describe("UserGetContainer", () => {
 
     renderContainer("42");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
     fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/client/src/app/features/user/containers/user-get-container.tsx
+++ b/client/src/app/features/user/containers/user-get-container.tsx
@@ -1,17 +1,43 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useGetUser } from "../hooks/use-get-user";
+import { useUpdateUser } from "../hooks/use-update-user";
 import { UserProfileView } from "../components/UserProfileView";
 import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
 import { Spinner } from "@shared/uis/Spinner.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
+import type { UserProfile } from "../types";
 
 export function UserGetContainer() {
   const { id } = useParams<{ id: string }>();
-  const { data, isLoading, error } = useGetUser(Number(id));
+  const numericId = Number(id);
+  const { data, isLoading, error } = useGetUser(numericId);
+  const {
+    submit: submitUpdate,
+    data: updated,
+    isLoading: isUpdating,
+    error: updateError,
+  } = useUpdateUser();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const text = useText();
 
-  if (isLoading) return <Spinner />;
-  if (error || !data) return <ErrorPanel message={text.userGetError} />;
+  useEffect(() => {
+    if (data) setProfile(data);
+  }, [data]);
 
-  return <UserProfileView profile={data} />;
+  useEffect(() => {
+    if (updated) setProfile(updated);
+  }, [updated]);
+
+  if (isLoading) return <Spinner />;
+  if (error || !profile) return <ErrorPanel message={text.userGetError} />;
+
+  return (
+    <UserProfileView
+      profile={profile}
+      onUpdate={(values) => submitUpdate(numericId, values)}
+      isUpdating={isUpdating}
+      updateError={updateError}
+    />
+  );
 }

--- a/client/src/app/features/user/hooks/__tests__/use-update-user.test.ts
+++ b/client/src/app/features/user/hooks/__tests__/use-update-user.test.ts
@@ -1,0 +1,218 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+jest.mock("../../apis", () => ({
+  updateUser: jest.fn(),
+}));
+
+jest.mock("../../mapper/to-update-user-request", () => ({
+  toUpdateUserRequest: jest.fn(),
+}));
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { useUpdateUser } from "../use-update-user";
+import { updateUser } from "../../apis";
+import { toUpdateUserRequest } from "../../mapper/to-update-user-request";
+import type { ApiUserDto, UpdateUserRequest } from "../../apis/user-api";
+import type { UpdateUserFormValues } from "../../mapper/to-update-user-request";
+import type { UserProfile } from "../../types";
+
+type UpdateFn = (
+  id: number,
+  request: UpdateUserRequest,
+  opts?: { signal?: AbortSignal },
+) => Promise<ApiUserDto>;
+const updateUserMock = updateUser as unknown as jest.MockedFunction<UpdateFn>;
+
+type MapFn = (values: UpdateUserFormValues) => UpdateUserRequest;
+const toUpdateUserRequestMock = toUpdateUserRequest as unknown as jest.MockedFunction<MapFn>;
+
+const formValues: UpdateUserFormValues = {
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+};
+
+const request: UpdateUserRequest = {
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+};
+
+const user: ApiUserDto = {
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+  age_range: "teens",
+  subscription_tier: "free",
+  subscription_expires_at: null,
+};
+
+const profile: UserProfile = {
+  id: 1,
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useUpdateUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    toUpdateUserRequestMock.mockReturnValue(request);
+  });
+
+  test("初期状態: data=null, isLoading=false, error=null", () => {
+    const { result } = renderHook(() => useUpdateUser());
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("成功パス: submit -> loading true -> data 反映 -> loading false", async () => {
+    const d = deferred<ApiUserDto>();
+    updateUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1, formValues);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      d.resolve(user);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual(profile);
+    expect(result.current.error).toBeNull();
+    expect(toUpdateUserRequestMock).toHaveBeenCalledWith(formValues);
+    expect(updateUserMock).toHaveBeenCalledWith(
+      1,
+      request,
+      expect.objectContaining({ signal: expect.any(Object) }),
+    );
+  });
+
+  test("通常エラー: error に反映され、data は null のまま", async () => {
+    const d = deferred<ApiUserDto>();
+    updateUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    const boom = new Error("boom");
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1, formValues);
+    });
+
+    await act(async () => {
+      d.reject(boom);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe(boom);
+  });
+
+  test("AbortError は無視される（エラー状態にしない）", async () => {
+    const d = deferred<ApiUserDto>();
+    updateUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1, formValues);
+    });
+
+    await act(async () => {
+      d.reject(new DOMException("Aborted", "AbortError"));
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  test("再送信時に前のリクエストを abort する", async () => {
+    const first = deferred<ApiUserDto>();
+    const second = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    updateUserMock.mockImplementation((_id, _req, opts) => {
+      signals.push(opts?.signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    const { result } = renderHook(() => useUpdateUser());
+
+    act(() => {
+      void result.current.submit(1, formValues);
+    });
+
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    let secondSubmit!: Promise<void>;
+    act(() => {
+      secondSubmit = result.current.submit(1, formValues);
+    });
+
+    await act(async () => {
+      second.resolve(user);
+      await secondSubmit;
+    });
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(result.current.data).toEqual(profile);
+  });
+
+  test("アンマウント時に現在のリクエストを abort する", () => {
+    const d = deferred<ApiUserDto>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    updateUserMock.mockImplementation((_id, _req, opts) => {
+      signals.push(opts?.signal);
+      return d.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useUpdateUser());
+
+    act(() => {
+      void result.current.submit(1, formValues);
+    });
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/client/src/app/features/user/hooks/use-update-user.ts
+++ b/client/src/app/features/user/hooks/use-update-user.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { updateUser } from "../apis";
+import { toUpdateUserRequest } from "../mapper/to-update-user-request";
+import { toUserProfile } from "../mapper/to-user-profile";
+import type { UpdateUserFormValues } from "../mapper/to-update-user-request";
+import type { UserProfile } from "../types";
+
+const isAbortError = (element: unknown): boolean => {
+  return element instanceof DOMException && element.name === "AbortError";
+};
+
+export function useUpdateUser() {
+  const [data, setData] = useState<UserProfile | null>(null);
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const submit = useCallback(async (id: number, values: UpdateUserFormValues) => {
+    abortRef.current?.abort();
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const updated = await updateUser(id, toUpdateUserRequest(values), {
+        signal: abortController.signal,
+      });
+      setData(toUserProfile(updated));
+    } catch (error) {
+      if (!isAbortError(error)) setError(error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { submit, data, isLoading, error };
+}

--- a/client/src/app/features/user/mapper/__tests__/to-update-user-request.test.ts
+++ b/client/src/app/features/user/mapper/__tests__/to-update-user-request.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "@jest/globals";
+import { toUpdateUserRequest } from "../to-update-user-request";
+import type { UpdateUserFormValues } from "../to-update-user-request";
+
+const makeFormValues = (overrides: Partial<UpdateUserFormValues> = {}): UpdateUserFormValues => ({
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ...overrides,
+});
+
+describe("toUpdateUserRequest", () => {
+  it("maps camelCase form values to snake_case request fields", () => {
+    const request = toUpdateUserRequest(makeFormValues());
+
+    expect(request).toEqual({
+      first_name: "Taro",
+      last_name: "Yamada",
+      email: "taro@example.com",
+    });
+  });
+
+  it("trims firstName, lastName, and email", () => {
+    const request = toUpdateUserRequest(
+      makeFormValues({
+        firstName: "  Taro  ",
+        lastName: "  Yamada  ",
+        email: "  taro@example.com  ",
+      }),
+    );
+
+    expect(request.first_name).toBe("Taro");
+    expect(request.last_name).toBe("Yamada");
+    expect(request.email).toBe("taro@example.com");
+  });
+});

--- a/client/src/app/features/user/mapper/to-update-user-request.ts
+++ b/client/src/app/features/user/mapper/to-update-user-request.ts
@@ -1,0 +1,10 @@
+import type { UserProfile } from "../types";
+import type { UpdateUserRequest } from "../apis/user-api";
+
+export type UpdateUserFormValues = Pick<UserProfile, "firstName" | "lastName" | "email">;
+
+export const toUpdateUserRequest = (values: UpdateUserFormValues): UpdateUserRequest => ({
+  first_name: values.firstName.trim(),
+  last_name: values.lastName.trim(),
+  email: values.email.trim(),
+});

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -75,5 +75,9 @@
   "userProfileTitle": "User Profile",
   "userGetError": "Failed to load user.",
   "userAgeRange": "Age Range",
-  "userSubscriptionTier": "Subscription"
+  "userSubscriptionTier": "Subscription",
+  "userUpdateEdit": "Edit",
+  "userUpdateSubmit": "Save",
+  "userUpdateCancel": "Cancel",
+  "userUpdateError": "Failed to update user."
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -75,5 +75,9 @@
   "userProfileTitle": "ユーザープロフィール",
   "userGetError": "ユーザー情報の取得に失敗しました。",
   "userAgeRange": "年代",
-  "userSubscriptionTier": "サブスクリプション"
+  "userSubscriptionTier": "サブスクリプション",
+  "userUpdateEdit": "編集",
+  "userUpdateSubmit": "保存",
+  "userUpdateCancel": "キャンセル",
+  "userUpdateError": "ユーザー情報の更新に失敗しました。"
 }


### PR DESCRIPTION
## Summary
- Add `updateUser(id, request)` API client (`PATCH /api/v1/users/:id`) and `UpdateUserRequest` type
- Add `toUpdateUserRequest` mapper (`UpdateUserFormValues` — `firstName`/`lastName`/`email` only — to the snake_case request body)
- Add `useUpdateUser` hook: manages `data`/`isLoading`/`error`, aborts the in-flight request on resubmit/unmount, and maps the response back to `UserProfile` via `toUserProfile`
- Wire update into the existing `/users/:id` page instead of a separate route: `UserGetContainer` now also drives `useUpdateUser` and holds the fetched profile as local state, overwriting it with the update result on success for immediate reflection without a reload
- `UserProfileView` gains per-field editing for `firstName`/`lastName`/`email`: clicking a row's "Edit" button turns only that row into an input pre-filled with its current value; `ageRange`/`subscriptionTier` stay read-only (not editable by design)
- Add `userUpdateEdit`/`userUpdateSubmit`/`userUpdateCancel`/`userUpdateError` i18n keys (en/ja)
- Validation relies on HTML5 (`required`/`type="email"`) for now; no JS validation library wired in yet
- Manually verified in the browser: editing a field and saving updates the profile immediately, no reload

## Related
Closes #416

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user`
- [x] `npx prettier --check` on the touched files
- [x] Manually verified in the browser