### PR TITLE
feat(user): add deleteUser API client

### DIFF
--- a/client/src/app/features/user/apis/index.test.ts
+++ b/client/src/app/features/user/apis/index.test.ts
@@ -216,6 +216,29 @@ describe("createUserApi", () => {
     });
   });
 
+  describe("deleteUser", () => {
+    it("sends a DELETE request to the users endpoint", async () => {
+      fetchSpy.mockResolvedValue({ ok: true, status: 204, json: async () => ({}) } as Response);
+
+      await api.deleteUser(1);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${USERS_ENDPOINT}/1`,
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({ Accept: "application/json" }),
+          credentials: "omit",
+        }),
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(404) as Response);
+
+      await expect(api.deleteUser(1)).rejects.toThrow("HTTP 404");
+    });
+  });
+
   it("throws when apiBase is empty", () => {
     expect(() => createUserApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
       "apiBase is required",

--- a/client/src/app/features/user/apis/index.ts
+++ b/client/src/app/features/user/apis/index.ts
@@ -11,3 +11,4 @@ const userApi = createUserApi({ apiBase });
 export const createUser = userApi.createUser;
 export const getUser = userApi.getUser;
 export const updateUser = userApi.updateUser;
+export const deleteUser = userApi.deleteUser;

--- a/client/src/app/features/user/apis/user-api.ts
+++ b/client/src/app/features/user/apis/user-api.ts
@@ -86,6 +86,17 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
     signal: init?.signal,
   });
 
+  const withDeleteInit = (init?: RequestInit): RequestInit => ({
+    ...init,
+    method: "DELETE",
+    headers: {
+      Accept: "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: init?.credentials ?? "omit",
+    signal: init?.signal,
+  });
+
   return {
     async createUser(request: CreateUserRequest, init?: RequestInit): Promise<ApiUserDto> {
       const response = await fetchImpl(createEndpoint, {
@@ -140,6 +151,14 @@ export const createUserApi = ({ apiBase, fetchImpl = fetch }: UserApiDeps) => {
       }
 
       return json.data;
+    },
+
+    async deleteUser(id: number, init?: RequestInit): Promise<void> {
+      const response = await fetchImpl(`${usersEndpoint}/${id}`, withDeleteInit(init));
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
     },
   };
 };


### PR DESCRIPTION
## Summary
- Add `deleteUser(id)` to the user API client (`DELETE /api/v1/users/:id`), returning `Promise<void>` since the endpoint responds `204 No Content` with no body
- No new type added to `types.ts` — deletion only needs the target `id`, there's no form-values object to model (unlike create/update)
- Export `deleteUser` from `apis/index.ts`

## Related
Closes #423

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/apis`
- [x] `npx prettier --check` on the touched files