### PR TITLE
feat(user): add useDeleteUser hook

### DIFF
--- a/client/src/app/features/user/hooks/__tests__/use-delete-user.test.ts
+++ b/client/src/app/features/user/hooks/__tests__/use-delete-user.test.ts
@@ -1,0 +1,168 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+jest.mock("../../apis", () => ({
+  deleteUser: jest.fn(),
+}));
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { useDeleteUser } from "../use-delete-user";
+import { deleteUser } from "../../apis";
+
+type DeleteFn = (id: number, opts?: { signal?: AbortSignal }) => Promise<void>;
+const deleteUserMock = deleteUser as unknown as jest.MockedFunction<DeleteFn>;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("useDeleteUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("初期状態: done=false, isLoading=false, error=null", () => {
+    const { result } = renderHook(() => useDeleteUser());
+
+    expect(result.current.done).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("成功パス: submit -> loading true -> done true -> loading false", async () => {
+    const d = deferred<void>();
+    deleteUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      d.resolve(undefined);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.done).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(deleteUserMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ signal: expect.any(Object) }),
+    );
+  });
+
+  test("通常エラー: error に反映され、done は false のまま", async () => {
+    const d = deferred<void>();
+    deleteUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    const boom = new Error("boom");
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1);
+    });
+
+    await act(async () => {
+      d.reject(boom);
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.done).toBe(false);
+    expect(result.current.error).toBe(boom);
+  });
+
+  test("AbortError は無視される（エラー状態にしない）", async () => {
+    const d = deferred<void>();
+    deleteUserMock.mockImplementation(() => d.promise);
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(1);
+    });
+
+    await act(async () => {
+      d.reject(new DOMException("Aborted", "AbortError"));
+      await submitPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.done).toBe(false);
+  });
+
+  test("再送信時に前のリクエストを abort する", async () => {
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    deleteUserMock.mockImplementation((_id, opts) => {
+      signals.push(opts?.signal);
+      return signals.length === 1 ? first.promise : second.promise;
+    });
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    act(() => {
+      void result.current.submit(1);
+    });
+
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    let secondSubmit!: Promise<void>;
+    act(() => {
+      secondSubmit = result.current.submit(1);
+    });
+
+    await act(async () => {
+      second.resolve(undefined);
+      await secondSubmit;
+    });
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(result.current.done).toBe(true);
+  });
+
+  test("アンマウント時に現在のリクエストを abort する", () => {
+    const d = deferred<void>();
+    const signals: Array<AbortSignal | undefined> = [];
+
+    deleteUserMock.mockImplementation((_id, opts) => {
+      signals.push(opts?.signal);
+      return d.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useDeleteUser());
+
+    act(() => {
+      void result.current.submit(1);
+    });
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/client/src/app/features/user/hooks/use-delete-user.ts
+++ b/client/src/app/features/user/hooks/use-delete-user.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { deleteUser } from "../apis";
+
+const isAbortError = (element: unknown): boolean => {
+  return element instanceof DOMException && element.name === "AbortError";
+};
+
+export function useDeleteUser() {
+  const [done, setDone] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const submit = useCallback(async (id: number) => {
+    abortRef.current?.abort();
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteUser(id, { signal: abortController.signal });
+      setDone(true);
+    } catch (error) {
+      if (!isAbortError(error)) setError(error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { submit, done, isLoading, error };
+}


### PR DESCRIPTION
## Summary
- Add `useDeleteUser` hook: manages `done`/`isLoading`/`error` state and a `submit(id)` function calling `deleteUser`
- Same `AbortController` handling as `useCreateUser`/`useUpdateUser`: aborts the in-flight request on resubmit and on unmount

## Related
Closes #425

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/user/hooks/__tests__/use-delete-user.test.ts`
- [x] `npx prettier --check` on the touched files