### PR TITLE
feat: share UserProfileContainer between /mypage and /users/:id

### DIFF
--- a/client/src/app/features/auth/containers/__tests__/mypage-container.test.tsx
+++ b/client/src/app/features/auth/containers/__tests__/mypage-container.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+
+const useAuthMock = jest.fn();
+const userProfileContainerMock = jest.fn();
+
+jest.mock("@shared/auth/AuthHooks.ts", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+jest.mock("@features/user/containers/user-profile-container.tsx", () => ({
+  UserProfileContainer: (props: { id: number }) => {
+    userProfileContainerMock(props);
+    return <div data-testid="id">{props.id}</div>;
+  },
+}));
+
+import { render, screen } from "@testing-library/react";
+import { MyPageContainer } from "../mypage-container";
+
+describe("MyPageContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a spinner while the authenticated user is not yet resolved", () => {
+    useAuthMock.mockReturnValue({ user: null, isLoading: true });
+
+    render(<MyPageContainer />);
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+    expect(userProfileContainerMock).not.toHaveBeenCalled();
+  });
+
+  it("renders UserProfileContainer with the authenticated user's id", () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 7, first_name: "Taro", last_name: "Yamada", email: "taro@example.com" },
+      isLoading: false,
+    });
+
+    render(<MyPageContainer />);
+
+    expect(userProfileContainerMock).toHaveBeenCalledWith({ id: 7 });
+    expect(screen.getByTestId("id").textContent).toBe("7");
+  });
+});

--- a/client/src/app/features/auth/containers/mypage-container.tsx
+++ b/client/src/app/features/auth/containers/mypage-container.tsx
@@ -1,19 +1,11 @@
 import { useAuth } from "@shared/auth/AuthHooks.ts";
-import { Button } from "@shared/uis/Button.tsx";
-import { useText } from "@shared/locale/ui-text.ts";
-import { useLogout } from "../hooks/use-logout";
+import { Spinner } from "@shared/uis/Spinner.tsx";
+import { UserProfileContainer } from "@features/user/containers/user-profile-container.tsx";
 
 export function MyPageContainer() {
   const { user } = useAuth();
-  const { submit, isLoading } = useLogout();
-  const text = useText();
 
-  return (
-    <div className="mx-auto flex max-w-xl flex-col items-center gap-4 px-4 py-12">
-      <p className="text-sm text-zinc-500">{user?.email}</p>
-      <Button type="button" variant="secondary" onClick={() => submit()} isLoading={isLoading}>
-        {text.logout}
-      </Button>
-    </div>
-  );
+  if (!user) return <Spinner />;
+
+  return <UserProfileContainer id={user.id} />;
 }

--- a/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-get-container.test.tsx
@@ -1,162 +1,36 @@
 /** @jest-environment jsdom */
 
-import type { UserProfile } from "../../types";
+const userProfileContainerMock = jest.fn();
 
-const useGetUserMock = jest.fn();
-const useUpdateUserMock = jest.fn();
-const useDeleteUserMock = jest.fn();
-
-jest.mock("../../hooks/use-get-user", () => ({
-  useGetUser: (id: number) => useGetUserMock(id),
+jest.mock("../user-profile-container", () => ({
+  UserProfileContainer: (props: { id: number }) => {
+    userProfileContainerMock(props);
+    return <div data-testid="id">{props.id}</div>;
+  },
 }));
 
-jest.mock("../../hooks/use-update-user", () => ({
-  useUpdateUser: () => useUpdateUserMock(),
-}));
-
-jest.mock("../../hooks/use-delete-user", () => ({
-  useDeleteUser: () => useDeleteUserMock(),
-}));
-
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
 import { UserGetContainer } from "../user-get-container";
 
-const profile: UserProfile = {
-  id: 1,
-  firstName: "Taro",
-  lastName: "Yamada",
-  email: "taro@example.com",
-  ageRange: "teens",
-  subscriptionTier: "free",
-  subscriptionExpiresAt: null,
-};
-
-const renderContainer = (id = "1") =>
+const renderContainer = (id: string) =>
   render(
     <MemoryRouter initialEntries={[`/users/${id}`]}>
-      <LocaleProvider>
-        <Routes>
-          <Route path="/users/:id" element={<UserGetContainer />} />
-          <Route path="/heritages" element={<div>Heritages Home</div>} />
-        </Routes>
-      </LocaleProvider>
+      <Routes>
+        <Route path="/users/:id" element={<UserGetContainer />} />
+      </Routes>
     </MemoryRouter>,
   );
 
 describe("UserGetContainer", () => {
-  const submitUpdateMock = jest.fn();
-  const submitDeleteMock = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
-    useUpdateUserMock.mockReturnValue({
-      submit: submitUpdateMock,
-      data: null,
-      isLoading: false,
-      error: null,
-    });
-    useDeleteUserMock.mockReturnValue({
-      submit: submitDeleteMock,
-      done: false,
-      isLoading: false,
-      error: null,
-    });
   });
 
-  it("shows a spinner while loading", () => {
-    useGetUserMock.mockReturnValue({ data: null, isLoading: true, error: null });
-
-    renderContainer();
-
-    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
-  });
-
-  it("passes the numeric id from the route to useGetUser", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-
+  it("passes the numeric id from the route to UserProfileContainer", () => {
     renderContainer("42");
 
-    expect(useGetUserMock).toHaveBeenCalledWith(42);
-  });
-
-  it("renders the user profile on success", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-
-    renderContainer();
-
-    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
-    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
-  });
-
-  it("shows an error panel when the hook reports an error", () => {
-    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: new Error("boom") });
-
-    renderContainer();
-
-    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
-  });
-
-  it("shows an error panel when data is missing after loading", () => {
-    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: null });
-
-    renderContainer();
-
-    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
-  });
-
-  it("calls useUpdateUser's submit with the numeric id and form values on save", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-
-    renderContainer("42");
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
-    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    expect(submitUpdateMock).toHaveBeenCalledWith(
-      42,
-      expect.objectContaining({ firstName: "Jiro", lastName: "Yamada", email: "taro@example.com" }),
-    );
-  });
-
-  it("reflects the updated profile immediately once useUpdateUser returns data", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-    useUpdateUserMock.mockReturnValue({
-      submit: submitUpdateMock,
-      data: { ...profile, firstName: "Jiro" },
-      isLoading: false,
-      error: null,
-    });
-
-    renderContainer();
-
-    expect(screen.getByText("Jiro Yamada")).toBeInTheDocument();
-  });
-
-  it("calls useDeleteUser's submit with the numeric id after confirming deletion", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-
-    renderContainer("42");
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete User" }));
-    fireEvent.click(screen.getByRole("button", { name: "Delete User" }));
-
-    expect(submitDeleteMock).toHaveBeenCalledWith(42);
-  });
-
-  it("navigates to /heritages once useDeleteUser reports done", () => {
-    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
-    useDeleteUserMock.mockReturnValue({
-      submit: submitDeleteMock,
-      done: true,
-      isLoading: false,
-      error: null,
-    });
-
-    renderContainer();
-
-    expect(screen.getByText("Heritages Home")).toBeInTheDocument();
+    expect(userProfileContainerMock).toHaveBeenCalledWith({ id: 42 });
+    expect(screen.getByTestId("id").textContent).toBe("42");
   });
 });

--- a/client/src/app/features/user/containers/__tests__/user-profile-container.test.tsx
+++ b/client/src/app/features/user/containers/__tests__/user-profile-container.test.tsx
@@ -1,0 +1,162 @@
+/** @jest-environment jsdom */
+
+import type { UserProfile } from "../../types";
+
+const useGetUserMock = jest.fn();
+const useUpdateUserMock = jest.fn();
+const useDeleteUserMock = jest.fn();
+
+jest.mock("../../hooks/use-get-user", () => ({
+  useGetUser: (id: number) => useGetUserMock(id),
+}));
+
+jest.mock("../../hooks/use-update-user", () => ({
+  useUpdateUser: () => useUpdateUserMock(),
+}));
+
+jest.mock("../../hooks/use-delete-user", () => ({
+  useDeleteUser: () => useDeleteUserMock(),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { UserProfileContainer } from "../user-profile-container";
+
+const profile: UserProfile = {
+  id: 1,
+  firstName: "Taro",
+  lastName: "Yamada",
+  email: "taro@example.com",
+  ageRange: "teens",
+  subscriptionTier: "free",
+  subscriptionExpiresAt: null,
+};
+
+const renderContainer = (id = 1) =>
+  render(
+    <MemoryRouter initialEntries={["/profile"]}>
+      <LocaleProvider>
+        <Routes>
+          <Route path="/profile" element={<UserProfileContainer id={id} />} />
+          <Route path="/heritages" element={<div>Heritages Home</div>} />
+        </Routes>
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("UserProfileContainer", () => {
+  const submitUpdateMock = jest.fn();
+  const submitDeleteMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useUpdateUserMock.mockReturnValue({
+      submit: submitUpdateMock,
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    useDeleteUserMock.mockReturnValue({
+      submit: submitDeleteMock,
+      done: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("shows a spinner while loading", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: true, error: null });
+
+    renderContainer();
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("passes the given id to useGetUser", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer(42);
+
+    expect(useGetUserMock).toHaveBeenCalledWith(42);
+  });
+
+  it("renders the user profile on success", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer();
+
+    expect(screen.getByText("Taro Yamada")).toBeInTheDocument();
+    expect(screen.getAllByText("taro@example.com").length).toBeGreaterThan(0);
+  });
+
+  it("shows an error panel when the hook reports an error", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: new Error("boom") });
+
+    renderContainer();
+
+    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+
+  it("shows an error panel when data is missing after loading", () => {
+    useGetUserMock.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    renderContainer();
+
+    expect(screen.getByText("Failed to load user.")).toBeInTheDocument();
+  });
+
+  it("calls useUpdateUser's submit with the given id and form values on save", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer(42);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit First Name" }));
+    fireEvent.change(screen.getByLabelText(/^First Name/), { target: { value: "Jiro" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitUpdateMock).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ firstName: "Jiro", lastName: "Yamada", email: "taro@example.com" }),
+    );
+  });
+
+  it("reflects the updated profile immediately once useUpdateUser returns data", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+    useUpdateUserMock.mockReturnValue({
+      submit: submitUpdateMock,
+      data: { ...profile, firstName: "Jiro" },
+      isLoading: false,
+      error: null,
+    });
+
+    renderContainer();
+
+    expect(screen.getByText("Jiro Yamada")).toBeInTheDocument();
+  });
+
+  it("calls useDeleteUser's submit with the given id after confirming deletion", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+
+    renderContainer(42);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete User" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete User" }));
+
+    expect(submitDeleteMock).toHaveBeenCalledWith(42);
+  });
+
+  it("navigates to /heritages once useDeleteUser reports done", () => {
+    useGetUserMock.mockReturnValue({ data: profile, isLoading: false, error: null });
+    useDeleteUserMock.mockReturnValue({
+      submit: submitDeleteMock,
+      done: true,
+      isLoading: false,
+      error: null,
+    });
+
+    renderContainer();
+
+    expect(screen.getByText("Heritages Home")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/features/user/containers/user-get-container.tsx
+++ b/client/src/app/features/user/containers/user-get-container.tsx
@@ -1,58 +1,8 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { useGetUser } from "../hooks/use-get-user";
-import { useUpdateUser } from "../hooks/use-update-user";
-import { useDeleteUser } from "../hooks/use-delete-user";
-import { UserProfileView } from "../components/UserProfileView";
-import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
-import { Spinner } from "@shared/uis/Spinner.tsx";
-import { useText } from "@shared/locale/ui-text.ts";
-import type { UserProfile } from "../types";
+import { useParams } from "react-router-dom";
+import { UserProfileContainer } from "./user-profile-container";
 
 export function UserGetContainer() {
   const { id } = useParams<{ id: string }>();
-  const numericId = Number(id);
-  const navigate = useNavigate();
-  const { data, isLoading, error } = useGetUser(numericId);
-  const {
-    submit: submitUpdate,
-    data: updated,
-    isLoading: isUpdating,
-    error: updateError,
-  } = useUpdateUser();
-  const {
-    submit: submitDelete,
-    done: isDeleted,
-    isLoading: isDeleting,
-    error: deleteError,
-  } = useDeleteUser();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
-  const text = useText();
 
-  useEffect(() => {
-    if (data) setProfile(data);
-  }, [data]);
-
-  useEffect(() => {
-    if (updated) setProfile(updated);
-  }, [updated]);
-
-  useEffect(() => {
-    if (isDeleted) navigate("/heritages");
-  }, [isDeleted, navigate]);
-
-  if (isLoading) return <Spinner />;
-  if (error || !profile) return <ErrorPanel message={text.userGetError} />;
-
-  return (
-    <UserProfileView
-      profile={profile}
-      onUpdate={(values) => submitUpdate(numericId, values)}
-      isUpdating={isUpdating}
-      updateError={updateError}
-      onDelete={() => submitDelete(numericId)}
-      isDeleting={isDeleting}
-      deleteError={deleteError}
-    />
-  );
+  return <UserProfileContainer id={Number(id)} />;
 }

--- a/client/src/app/features/user/containers/user-profile-container.tsx
+++ b/client/src/app/features/user/containers/user-profile-container.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useGetUser } from "../hooks/use-get-user";
+import { useUpdateUser } from "../hooks/use-update-user";
+import { useDeleteUser } from "../hooks/use-delete-user";
+import { UserProfileView } from "../components/UserProfileView";
+import { ErrorPanel } from "@shared/uis/ErrorPanel.tsx";
+import { Spinner } from "@shared/uis/Spinner.tsx";
+import { useText } from "@shared/locale/ui-text.ts";
+import type { UserProfile } from "../types";
+
+type Props = {
+  id: number;
+};
+
+export function UserProfileContainer({ id }: Props) {
+  const navigate = useNavigate();
+  const { data, isLoading, error } = useGetUser(id);
+  const {
+    submit: submitUpdate,
+    data: updated,
+    isLoading: isUpdating,
+    error: updateError,
+  } = useUpdateUser();
+  const {
+    submit: submitDelete,
+    done: isDeleted,
+    isLoading: isDeleting,
+    error: deleteError,
+  } = useDeleteUser();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const text = useText();
+
+  useEffect(() => {
+    if (data) setProfile(data);
+  }, [data]);
+
+  useEffect(() => {
+    if (updated) setProfile(updated);
+  }, [updated]);
+
+  useEffect(() => {
+    if (isDeleted) navigate("/heritages");
+  }, [isDeleted, navigate]);
+
+  if (isLoading) return <Spinner />;
+  if (error || !profile) return <ErrorPanel message={text.userGetError} />;
+
+  return (
+    <UserProfileView
+      profile={profile}
+      onUpdate={(values) => submitUpdate(id, values)}
+      isUpdating={isUpdating}
+      updateError={updateError}
+      onDelete={() => submitDelete(id)}
+      isDeleting={isDeleting}
+      deleteError={deleteError}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `UserProfileContainer` (accepts `id: number` as a prop): owns the get/update/delete hooks, immediate-reflection state, and renders `UserProfileView` — this is the shared implementation
- `UserGetContainer` (`/users/:id`) becomes a thin wrapper: reads `id` from the route param, passes it through
- `MyPageContainer` (`/mypage`) becomes a thin wrapper: reads `id` from `useAuth().user.id` (the authenticated user's own id), passes it through
- No URL redirect — `/mypage` stays `/mypage`, it just renders the same component tree as viewing your own `/users/:id`
- Removes the standalone logout button that was on the `/mypage` placeholder (tracked separately, not re-added here)
- Tests reorganized to match: detailed behavior tests moved to `user-profile-container.test.tsx`; `user-get-container.test.tsx` and the new `mypage-container.test.tsx` only verify each wrapper passes the right id through

## Related
Closes #468

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` (206 tests)
- [x] `npm run format:check`
- [x] `npm run build`