### PR TITLE
fix(auth): stop reload from redirecting logged-in users to /login

### DIFF
--- a/client/src/shared/auth/AuthProvider.tsx
+++ b/client/src/shared/auth/AuthProvider.tsx
@@ -6,6 +6,10 @@ import { getStoredToken, clearStoredToken } from "./token-storage.ts";
 
 export type AuthUser = ApiCurrentUserDto;
 
+const isAbortError = (e: unknown): boolean => {
+  return e instanceof DOMException && e.name === "AbortError";
+};
+
 const AuthContext = createContext<
   | {
       user: AuthUser | null;
@@ -33,8 +37,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         setUser(current);
         if (!current) clearStoredToken();
       })
-      .catch(() => setUser(null))
-      .finally(() => setLoading(false));
+      .catch((e) => {
+        if (!isAbortError(e)) setUser(null);
+      })
+      .finally(() => {
+        if (!abortController.signal.aborted) setLoading(false);
+      });
 
     return () => abortController.abort();
   }, []);

--- a/client/src/shared/auth/__tests__/AuthProvider.test.tsx
+++ b/client/src/shared/auth/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,73 @@
+/** @jest-environment jsdom */
+
+const getCurrentUserMock = jest.fn();
+
+jest.mock("@features/auth/apis", () => ({
+  getCurrentUser: (...args: unknown[]) => getCurrentUserMock(...args),
+}));
+
+import { StrictMode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider } from "../AuthProvider";
+import { useAuth } from "../AuthHooks";
+import type { ApiCurrentUserDto } from "@features/auth/apis/auth-api.ts";
+
+const user: ApiCurrentUserDto = {
+  id: 1,
+  first_name: "Taro",
+  last_name: "Yamada",
+  email: "taro@example.com",
+};
+
+type LogEntry = { isLoading: boolean; user: unknown };
+
+function Probe({ log }: { log: LogEntry[] }) {
+  const { isLoading, user } = useAuth();
+  log.push({ isLoading, user });
+  return <div data-testid="state">{isLoading ? "loading" : user ? "authed" : "guest"}</div>;
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    localStorage.setItem("auth_token", "tok-123");
+    getCurrentUserMock.mockReset();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not report logged-out while the request from a StrictMode-duplicated effect is still in flight", async () => {
+    getCurrentUserMock.mockImplementation(
+      (_token: string, init?: { signal?: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          const signal = init?.signal;
+          if (signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          const onAbort = () => reject(new DOMException("Aborted", "AbortError"));
+          signal?.addEventListener("abort", onAbort);
+          setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve(user);
+          }, 20);
+        }),
+    );
+
+    const log: LogEntry[] = [];
+
+    render(
+      <StrictMode>
+        <AuthProvider>
+          <Probe log={log} />
+        </AuthProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("state").textContent).toBe("authed"));
+
+    const wronglyReportedLoggedOut = log.some((entry) => !entry.isLoading && entry.user === null);
+    expect(wronglyReportedLoggedOut).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Bug: reloading an auth-required page (e.g. `/mypage`) while logged in redirected to `/login`, even though the token was still valid in `localStorage`
- Root cause: `<StrictMode>` double-invokes `AuthProvider`'s effect in dev. The first invocation's `getCurrentUser` call gets aborted by React's Strict Mode cleanup, but `AuthProvider` didn't check for `AbortError` before calling `setUser(null)`/`setLoading(false)` — unlike every other hook in this codebase (`useCreateUser`, etc.), which all guard against acting on an aborted request's result. The aborted call's rejection resolved before the second (real) request finished, so `RequireAuth` briefly saw `isLoading:false, user:null` and navigated away before the real request could complete
- Fix: guard `AuthProvider`'s `getCurrentUser` `.catch`/`.finally` with the same `isAbortError` check used elsewhere


## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` — added a regression test that reproduces the StrictMode double-effect race; confirmed it fails against the pre-fix code and passes with the fix
- [x] `npm run format:check`