### PR TITLE
feat(auth): add AuthNavContainer with Login/MyPage/Logout nav

### DIFF
--- a/client/src/app/features/auth/containers/__tests__/auth-nav-container.test.tsx
+++ b/client/src/app/features/auth/containers/__tests__/auth-nav-container.test.tsx
@@ -1,0 +1,80 @@
+/** @jest-environment jsdom */
+
+const useAuthMock = jest.fn();
+const useLogoutMock = jest.fn();
+
+jest.mock("@shared/auth/AuthHooks.ts", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+jest.mock("../../hooks/use-logout", () => ({
+  useLogout: () => useLogoutMock(),
+}));
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LocaleProvider } from "@shared/locale/LocaleProvider.tsx";
+import { AuthNavContainer } from "../auth-nav-container";
+
+const renderNav = () =>
+  render(
+    <MemoryRouter>
+      <LocaleProvider>
+        <AuthNavContainer />
+      </LocaleProvider>
+    </MemoryRouter>,
+  );
+
+describe("AuthNavContainer", () => {
+  const submitMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLogoutMock.mockReturnValue({ submit: submitMock, isLoading: false, error: null });
+  });
+
+  it("renders nothing while the auth state is still loading", () => {
+    useAuthMock.mockReturnValue({ user: null, isLoading: true });
+
+    renderNav();
+
+    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "My Page" })).not.toBeInTheDocument();
+  });
+
+  it("shows a Login link when unauthenticated", () => {
+    useAuthMock.mockReturnValue({ user: null, isLoading: false });
+
+    renderNav();
+
+    expect(screen.getByRole("link", { name: "Login" })).toHaveAttribute("href", "/login");
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
+  });
+
+  it("shows My Page and Logout when authenticated", () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 1, first_name: "Taro", last_name: "Yamada", email: "taro@example.com" },
+      isLoading: false,
+    });
+
+    renderNav();
+
+    expect(screen.getByRole("link", { name: "My Page" })).toHaveAttribute("href", "/mypage");
+    expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+  });
+
+  it("calls useLogout's submit when Logout is clicked", async () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 1, first_name: "Taro", last_name: "Yamada", email: "taro@example.com" },
+      isLoading: false,
+    });
+    submitMock.mockResolvedValue(true);
+
+    renderNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+  });
+});

--- a/client/src/app/features/auth/containers/auth-nav-container.tsx
+++ b/client/src/app/features/auth/containers/auth-nav-container.tsx
@@ -1,0 +1,48 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useText } from "@shared/locale/ui-text.ts";
+import { useAuth } from "@shared/auth/AuthHooks.ts";
+import { useLogout } from "../hooks/use-logout";
+
+export function AuthNavContainer() {
+  const { user, isLoading } = useAuth();
+  const { submit, isLoading: isLoggingOut } = useLogout();
+  const navigate = useNavigate();
+  const text = useText();
+
+  if (isLoading) return null;
+
+  if (!user) {
+    return (
+      <Link
+        to="/login"
+        className="rounded-full px-3 py-1.5 text-xs font-semibold text-zinc-600 hover:bg-zinc-100"
+      >
+        {text.login}
+      </Link>
+    );
+  }
+
+  const handleLogout = async () => {
+    await submit();
+    navigate("/heritages");
+  };
+
+  return (
+    <>
+      <Link
+        to="/mypage"
+        className="rounded-full px-3 py-1.5 text-xs font-semibold text-zinc-600 hover:bg-zinc-100"
+      >
+        {text.myPage}
+      </Link>
+      <button
+        type="button"
+        onClick={handleLogout}
+        disabled={isLoggingOut}
+        className="rounded-full border border-zinc-200 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+      >
+        {text.logout}
+      </button>
+    </>
+  );
+}

--- a/client/src/locals/en/ui.json
+++ b/client/src/locals/en/ui.json
@@ -87,5 +87,6 @@
   "login": "Login",
   "loginError": "Failed to log in.",
   "logout": "Log out",
-  "userUpgradeToPaid": "Upgrade to Paid"
+  "userUpgradeToPaid": "Upgrade to Paid",
+  "myPage": "My Page"
 }

--- a/client/src/locals/ja/ui.json
+++ b/client/src/locals/ja/ui.json
@@ -87,5 +87,6 @@
   "login": "ログイン",
   "loginError": "ログインに失敗しました。",
   "logout": "ログアウト",
-  "userUpgradeToPaid": "有料プランへアップグレード"
+  "userUpgradeToPaid": "有料プランへアップグレード",
+  "myPage": "マイページ"
 }

--- a/client/src/shared/layout/AppHeader.tsx
+++ b/client/src/shared/layout/AppHeader.tsx
@@ -2,6 +2,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import PublicIcon from "@mui/icons-material/Public";
 import { LocaleToggle } from "@shared/locale/LocaleToggle.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
+import { AuthNavContainer } from "@features/auth/containers/auth-nav-container.tsx";
 import { STUDY_REGIONS } from "../../domain/types.ts";
 
 export function AppHeader() {
@@ -46,6 +47,7 @@ export function AppHeader() {
         </nav>
 
         <div className="flex shrink-0 items-center gap-2">
+          <AuthNavContainer />
           <LocaleToggle />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `AuthNavContainer` (`features/auth/containers/auth-nav-container.tsx`): shows a "Login" link when unauthenticated, and "My Page" + "Logout" when authenticated, using `useAuth()`/`useLogout()`. Logout navigates to `/heritages` on success
- Wire it into `AppHeader` (shared across all pages)
- `logout`/`login`/`myPage` API and hook logic already existed from the login feature — this only adds the missing UI trigger
- Add `myPage` i18n key (en/ja)

## Related
Closes #471
Closes #472

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` (213 tests)
- [x] `npm run format:check`
- [x] `npm run lint`