### PR TITLE
feat(favorites): add favorites API client (add/remove)

### DIFF
--- a/client/src/app/features/favorites/apis/favorites-api.test.ts
+++ b/client/src/app/features/favorites/apis/favorites-api.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { createFavoritesApi } from "./favorites-api";
+import type { AddFavoriteRequest } from "./favorites-api";
+
+type MockResponse = Pick<Response, "ok" | "status" | "json">;
+
+let fetchSpy: jest.MockedFunction<typeof fetch>;
+
+const API_BASE = "http://localhost:8700";
+const TOKEN = "1|abcdef";
+const FAVORITES_ENDPOINT = `${API_BASE}/api/v1/users/me/favorites`;
+
+const makeOkResponse = (): MockResponse => ({
+  ok: true,
+  status: 204,
+  json: async () => ({}),
+});
+
+const makeNgResponse = (status: number): MockResponse => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+});
+
+const makeAddRequest = (overrides: Partial<AddFavoriteRequest> = {}): AddFavoriteRequest => ({
+  user_id: 1,
+  heritage_id: 42,
+  is_liked: true,
+  ...overrides,
+});
+
+describe("createFavoritesApi", () => {
+  let api: ReturnType<typeof createFavoritesApi>;
+
+  beforeEach(() => {
+    fetchSpy = jest.fn() as jest.MockedFunction<typeof fetch>;
+    api = createFavoritesApi({ apiBase: API_BASE, fetchImpl: fetchSpy });
+  });
+
+  it("throws when apiBase is empty", () => {
+    expect(() => createFavoritesApi({ apiBase: "", fetchImpl: fetchSpy })).toThrow(
+      "apiBase is required",
+    );
+  });
+
+  describe("addFavorite", () => {
+    it("posts the request body with the bearer token", async () => {
+      fetchSpy.mockResolvedValue(makeOkResponse() as Response);
+
+      const request = makeAddRequest();
+      await api.addFavorite(request, TOKEN);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        FAVORITES_ENDPOINT,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(request),
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          }),
+        }),
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+
+      await expect(api.addFavorite(makeAddRequest(), TOKEN)).rejects.toThrow("HTTP 422");
+    });
+  });
+
+  describe("removeFavorite", () => {
+    it("deletes by heritage id with the bearer token", async () => {
+      fetchSpy.mockResolvedValue(makeOkResponse() as Response);
+
+      await api.removeFavorite(42, TOKEN);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${FAVORITES_ENDPOINT}/42`,
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          }),
+        }),
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      fetchSpy.mockResolvedValue(makeNgResponse(404) as Response);
+
+      await expect(api.removeFavorite(42, TOKEN)).rejects.toThrow("HTTP 404");
+    });
+  });
+});

--- a/client/src/app/features/favorites/apis/favorites-api.test.ts
+++ b/client/src/app/features/favorites/apis/favorites-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { createFavoritesApi } from "./favorites-api";
 import type { AddFavoriteRequest } from "./favorites-api";
+import type { ApiWorldHeritageDto } from "../../../../domain/types.ts";
 
 type MockResponse = Pick<Response, "ok" | "status" | "json">;
 
@@ -8,12 +9,12 @@ let fetchSpy: jest.MockedFunction<typeof fetch>;
 
 const API_BASE = "http://localhost:8700";
 const TOKEN = "1|abcdef";
-const FAVORITES_ENDPOINT = `${API_BASE}/api/v1/users/me/favorites`;
+const FAVORITES_ENDPOINT = `${API_BASE}/api/v1/favorites`;
 
-const makeOkResponse = (): MockResponse => ({
+const makeAddedResponse = (): MockResponse => ({
   ok: true,
-  status: 204,
-  json: async () => ({}),
+  status: 201,
+  json: async () => ({ status: "success" }),
 });
 
 const makeNgResponse = (status: number): MockResponse => ({
@@ -23,9 +24,33 @@ const makeNgResponse = (status: number): MockResponse => ({
 });
 
 const makeAddRequest = (overrides: Partial<AddFavoriteRequest> = {}): AddFavoriteRequest => ({
-  user_id: 1,
-  heritage_id: 42,
-  is_liked: true,
+  world_heritage_id: 42,
+  ...overrides,
+});
+
+const makeHeritageDto = (overrides: Partial<ApiWorldHeritageDto> = {}): ApiWorldHeritageDto => ({
+  id: 1,
+  official_name: "Official Name",
+  name: "Name",
+  heritage_name_jp: "名前",
+  country: "Country",
+  country_name_jp: "国名",
+  region: "Europe",
+  category: "Cultural",
+  year_inscribed: 2000,
+  latitude: 0,
+  longitude: 0,
+  is_endangered: false,
+  criteria: ["i"],
+  area_hectares: null,
+  buffer_zone_hectares: null,
+  short_description: "desc",
+  short_description_jp: "説明",
+  unesco_site_url: null,
+  state_party: null,
+  state_party_codes: [],
+  state_parties_meta: {},
+  thumbnail_url: null,
   ...overrides,
 });
 
@@ -45,7 +70,7 @@ describe("createFavoritesApi", () => {
 
   describe("addFavorite", () => {
     it("posts the request body with the bearer token", async () => {
-      fetchSpy.mockResolvedValue(makeOkResponse() as Response);
+      fetchSpy.mockResolvedValue(makeAddedResponse() as Response);
 
       const request = makeAddRequest();
       await api.addFavorite(request, TOKEN);
@@ -65,34 +90,52 @@ describe("createFavoritesApi", () => {
     });
 
     it("throws on HTTP error", async () => {
-      fetchSpy.mockResolvedValue(makeNgResponse(422) as Response);
+      fetchSpy.mockResolvedValue(makeNgResponse(404) as Response);
 
-      await expect(api.addFavorite(makeAddRequest(), TOKEN)).rejects.toThrow("HTTP 422");
+      await expect(api.addFavorite(makeAddRequest(), TOKEN)).rejects.toThrow("HTTP 404");
     });
   });
 
-  describe("removeFavorite", () => {
-    it("deletes by heritage id with the bearer token", async () => {
-      fetchSpy.mockResolvedValue(makeOkResponse() as Response);
+  describe("getFavorites", () => {
+    it("fetches the list with the bearer token and returns the data", async () => {
+      const heritages = [makeHeritageDto()];
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", data: heritages }),
+      } as Response);
 
-      await api.removeFavorite(42, TOKEN);
+      const result = await api.getFavorites(TOKEN);
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${FAVORITES_ENDPOINT}/42`,
+        FAVORITES_ENDPOINT,
         expect.objectContaining({
-          method: "DELETE",
+          method: "GET",
           headers: expect.objectContaining({
             Accept: "application/json",
             Authorization: `Bearer ${TOKEN}`,
           }),
         }),
       );
+      expect(result).toEqual(heritages);
+    });
+
+    it("returns an empty array when there are no favorites", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", data: [] }),
+      } as Response);
+
+      const result = await api.getFavorites(TOKEN);
+
+      expect(result).toEqual([]);
     });
 
     it("throws on HTTP error", async () => {
-      fetchSpy.mockResolvedValue(makeNgResponse(404) as Response);
+      fetchSpy.mockResolvedValue(makeNgResponse(500) as Response);
 
-      await expect(api.removeFavorite(42, TOKEN)).rejects.toThrow("HTTP 404");
+      await expect(api.getFavorites(TOKEN)).rejects.toThrow("HTTP 500");
     });
   });
 });

--- a/client/src/app/features/favorites/apis/favorites-api.ts
+++ b/client/src/app/features/favorites/apis/favorites-api.ts
@@ -1,12 +1,17 @@
+import type { ApiWorldHeritageDto } from "../../../../domain/types.ts";
+
 export type FavoritesApiDeps = {
   apiBase: string;
   fetchImpl?: typeof fetch;
 };
 
 export type AddFavoriteRequest = {
-  user_id: number;
-  heritage_id: number;
-  is_liked: boolean;
+  world_heritage_id: number;
+};
+
+type ApiEnvelope<T> = {
+  status: string;
+  data: T;
 };
 
 const normalizeApiBase = (apiBase: string): string => apiBase.replace(/\/+$/, "");
@@ -21,7 +26,7 @@ export const createFavoritesApi = ({ apiBase, fetchImpl = fetch }: FavoritesApiD
   }
 
   const base = normalizeApiBase(apiBase);
-  const favoritesEndpoint = `${base}/api/v1/users/me/favorites`;
+  const favoritesEndpoint = `${base}/api/v1/favorites`;
 
   return {
     async addFavorite(
@@ -46,10 +51,10 @@ export const createFavoritesApi = ({ apiBase, fetchImpl = fetch }: FavoritesApiD
       }
     },
 
-    async removeFavorite(heritageId: number, token: string, init?: RequestInit): Promise<void> {
-      const response = await fetchImpl(`${favoritesEndpoint}/${heritageId}`, {
+    async getFavorites(token: string, init?: RequestInit): Promise<ApiWorldHeritageDto[]> {
+      const response = await fetchImpl(favoritesEndpoint, {
         ...init,
-        method: "DELETE",
+        method: "GET",
         headers: {
           Accept: "application/json",
           ...withAuthHeader(token),
@@ -60,6 +65,9 @@ export const createFavoritesApi = ({ apiBase, fetchImpl = fetch }: FavoritesApiD
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
+
+      const body = (await response.json()) as ApiEnvelope<ApiWorldHeritageDto[]>;
+      return body.data;
     },
   };
 };

--- a/client/src/app/features/favorites/apis/favorites-api.ts
+++ b/client/src/app/features/favorites/apis/favorites-api.ts
@@ -1,0 +1,65 @@
+export type FavoritesApiDeps = {
+  apiBase: string;
+  fetchImpl?: typeof fetch;
+};
+
+export type AddFavoriteRequest = {
+  user_id: number;
+  heritage_id: number;
+  is_liked: boolean;
+};
+
+const normalizeApiBase = (apiBase: string): string => apiBase.replace(/\/+$/, "");
+
+const withAuthHeader = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+});
+
+export const createFavoritesApi = ({ apiBase, fetchImpl = fetch }: FavoritesApiDeps) => {
+  if (!apiBase) {
+    throw new Error("apiBase is required");
+  }
+
+  const base = normalizeApiBase(apiBase);
+  const favoritesEndpoint = `${base}/api/v1/users/me/favorites`;
+
+  return {
+    async addFavorite(
+      request: AddFavoriteRequest,
+      token: string,
+      init?: RequestInit,
+    ): Promise<void> {
+      const response = await fetchImpl(favoritesEndpoint, {
+        ...init,
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          ...withAuthHeader(token),
+          ...(init?.headers ?? {}),
+        },
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+    },
+
+    async removeFavorite(heritageId: number, token: string, init?: RequestInit): Promise<void> {
+      const response = await fetchImpl(`${favoritesEndpoint}/${heritageId}`, {
+        ...init,
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+          ...withAuthHeader(token),
+          ...(init?.headers ?? {}),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+    },
+  };
+};

--- a/client/src/app/features/favorites/apis/index.ts
+++ b/client/src/app/features/favorites/apis/index.ts
@@ -1,0 +1,12 @@
+import { createFavoritesApi } from "./favorites-api.ts";
+
+const apiBase = import.meta.env.VITE_API_BASE_URL;
+
+if (!apiBase) {
+  throw new Error("VITE_API_BASE_URL is not set");
+}
+
+const favoritesApi = createFavoritesApi({ apiBase });
+
+export const addFavorite = favoritesApi.addFavorite;
+export const removeFavorite = favoritesApi.removeFavorite;

--- a/client/src/app/features/favorites/apis/index.ts
+++ b/client/src/app/features/favorites/apis/index.ts
@@ -9,4 +9,4 @@ if (!apiBase) {
 const favoritesApi = createFavoritesApi({ apiBase });
 
 export const addFavorite = favoritesApi.addFavorite;
-export const removeFavorite = favoritesApi.removeFavorite;
+export const getFavorites = favoritesApi.getFavorites;


### PR DESCRIPTION
## Summary

### What I have done
- Added `favorites-api.ts`: `AddFavoriteRequest` type, `addFavorite(request, token)` (`POST /api/v1/favorites`, body `{ world_heritage_id }`, `201` `{ status: "success" }`)
- Added `getFavorites(token)` (`GET /api/v1/favorites`, `200` `{ status: "success", data: ApiWorldHeritageDto[] }`) — reuses the existing `ApiWorldHeritageDto` type since the list item shape matches it exactly
- Bearer token auth, following the same pattern as `auth-api.ts` (`logout`/`getCurrentUser`)
- Dropped `removeFavorite` — its endpoint spec isn't confirmed yet, will be added in a separate PR once confirmed
- No `types.ts` addition for the add request — same reasoning as the user-delete feature: it's a simple pass-through with no camelCase/snake_case transformation to encapsulate

## Related
Part of #486
Part of #487 — covers `addFavorite`/`getFavorites`. `removeFavorite` is deferred to a separate PR once its endpoint spec is confirmed.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/app/features/favorites`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`