### PR TITLE
feat(favorites): add favorite add-button container

### DIFF
--- a/client/src/app/features/favorites/containers/__tests__/favorite-button-container.test.tsx
+++ b/client/src/app/features/favorites/containers/__tests__/favorite-button-container.test.tsx
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+
+import { jest } from "@jest/globals";
+
+const submitMock = jest.fn();
+let useAddFavoriteReturn: { submit: typeof submitMock; isAdded: boolean; isLoading: boolean };
+let useAuthReturn: { user: { id: number } | null };
+
+jest.mock("../../hooks/use-add-favorite", () => ({
+  useAddFavorite: () => useAddFavoriteReturn,
+}));
+
+jest.mock("@shared/auth/AuthHooks.ts", () => ({
+  useAuth: () => useAuthReturn,
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { FavoriteButtonContainer } from "../favorite-button-container";
+
+describe("FavoriteButtonContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAddFavoriteReturn = { submit: submitMock, isAdded: false, isLoading: false };
+    useAuthReturn = { user: { id: 1 } };
+  });
+
+  test("未ログインの場合は何も表示しない", () => {
+    useAuthReturn = { user: null };
+
+    const { container } = render(<FavoriteButtonContainer heritageId={42} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("ログイン中はボタンが表示され、クリックでsubmitが呼ばれる", () => {
+    render(<FavoriteButtonContainer heritageId={42} />);
+
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    fireEvent.click(button);
+
+    expect(submitMock).toHaveBeenCalledWith(42);
+  });
+
+  test("isAdded=trueの場合は登録済み表示になり、ボタンは無効化される", () => {
+    useAddFavoriteReturn = { submit: submitMock, isAdded: true, isLoading: false };
+
+    render(<FavoriteButtonContainer heritageId={42} />);
+
+    const button = screen.getByRole("button", { name: "Favorited" });
+    expect(button).toBeDisabled();
+  });
+
+  test("isLoading=trueの場合はボタンが無効化される", () => {
+    useAddFavoriteReturn = { submit: submitMock, isAdded: false, isLoading: true };
+
+    render(<FavoriteButtonContainer heritageId={42} />);
+
+    expect(screen.getByRole("button", { name: "Add to favorites" })).toBeDisabled();
+  });
+});

--- a/client/src/app/features/favorites/containers/__tests__/favorite-button-container.test.tsx
+++ b/client/src/app/features/favorites/containers/__tests__/favorite-button-container.test.tsx
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 
+import "@testing-library/jest-dom/jest-globals";
 import { jest } from "@jest/globals";
 
 const submitMock = jest.fn();

--- a/client/src/app/features/favorites/containers/favorite-button-container.tsx
+++ b/client/src/app/features/favorites/containers/favorite-button-container.tsx
@@ -1,0 +1,27 @@
+import { useAddFavorite } from "../hooks/use-add-favorite";
+import { useAuth } from "@shared/auth/AuthHooks.ts";
+
+export function FavoriteButtonContainer({ heritageId }: { heritageId: number }) {
+  const { user } = useAuth();
+  const { submit, isAdded, isLoading } = useAddFavorite();
+
+  if (!user) return null;
+
+  const handleClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void submit(heritageId);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={isAdded ? "Favorited" : "Add to favorites"}
+      aria-pressed={isAdded}
+      disabled={isLoading || isAdded}
+      onClick={handleClick}
+    >
+      {isAdded ? "♥" : "♡"}
+    </button>
+  );
+}

--- a/client/src/app/features/top/cards/HeritageCard.tsx
+++ b/client/src/app/features/top/cards/HeritageCard.tsx
@@ -1,6 +1,7 @@
 import type { WorldHeritageVm } from "../../../../domain/types.ts";
 import { BaseCard } from "@shared/uis/BaseCard.tsx";
 import { useText } from "@shared/locale/ui-text.ts";
+import { FavoriteButtonContainer } from "@features/favorites/containers/favorite-button-container.tsx";
 
 export function HeritageCard({
   item,
@@ -52,6 +53,10 @@ export function HeritageCard({
         )}
 
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+
+        <div className="absolute left-3 top-3">
+          <FavoriteButtonContainer heritageId={item.id} />
+        </div>
 
         {item.isEndangered && (
           <div className="absolute right-3 top-3">

--- a/client/src/app/features/top/components/heritage-detail/HeritageHero.tsx
+++ b/client/src/app/features/top/components/heritage-detail/HeritageHero.tsx
@@ -1,5 +1,6 @@
 import type { WorldHeritageDetailVm, WorldHeritageImageVm } from "../../../../../domain/types.ts";
 import { useText } from "@shared/locale/ui-text.ts";
+import { FavoriteButtonContainer } from "@features/favorites/containers/favorite-button-container.tsx";
 
 export function HeritageHero({ item }: { item: WorldHeritageDetailVm }) {
   const text = useText();
@@ -9,14 +10,17 @@ export function HeritageHero({ item }: { item: WorldHeritageDetailVm }) {
   return (
     <header className="mx-auto w-full max-w-6xl px-4 pt-10 pb-6">
       <div className="mb-5 md:mb-6">
-        <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-zinc-900">
-          {item.title}
-          {item.displaySubName && (
-            <span className="ml-2 text-xl md:text-2xl font-bold text-zinc-500">
-              （{item.displaySubName}）
-            </span>
-          )}
-        </h1>
+        <div className="flex items-start gap-3">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-zinc-900">
+            {item.title}
+            {item.displaySubName && (
+              <span className="ml-2 text-xl md:text-2xl font-bold text-zinc-500">
+                （{item.displaySubName}）
+              </span>
+            )}
+          </h1>
+          <FavoriteButtonContainer heritageId={item.id} />
+        </div>
 
         {item.subtitle && (
           <p className="mt-2 text-sm font-medium text-zinc-700 md:text-base">{item.subtitle}</p>


### PR DESCRIPTION
## Summary

### What I have done
- Added `FavoriteButtonContainer` (`client/src/app/features/favorites/containers/favorite-button-container.tsx`): wires `useAuth` + `useAddFavorite` per heritage id, renders nothing when logged out
- Rendered as a **placeholder button only** (♡/♥ text, no styling) — the real heart icon UI is intentionally a separate issue/branch, per this repo's convention of splitting hooks/mapper/container/UI into distinct Issues
- Wired it into `HeritageCard.tsx` (top-left overlay on the thumbnail) and `HeritageHero.tsx` (next to the title on the detail page), covering both the heritage list/cards and the detail page as decided in #486
- Added tests: logged-out renders nothing, click calls `submit(heritageId)`, disabled while loading, disabled/labelled "Favorited" once added

## Related
Part of #487
Closes the container scope of #490

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` (full suite, 44 suites / 230 tests, no regressions)
- [x] `npm run format:check`
- [x] `npm run lint`